### PR TITLE
Fix redirect hook

### DIFF
--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -73,7 +73,9 @@ const applicationStatus = {
               confirmation: viewModel,
             });
             await cacheService.clearState(request);
-
+            if (state.callback?.returnUrl) {
+              return h.redirect(state.callback?.returnUrl);
+            }
             return h.view("confirmation", viewModel);
           },
         },

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -173,9 +173,6 @@ export class SummaryPageController extends PageController {
       /**
        * If a user does not need to pay, redirect them to /status
        */
-      // if (summaryViewModel.callback?.returnUrl) {
-      //   return h.redirect(summaryViewModel.callback?.returnUrl);
-      // }
       if (
         !summaryViewModel.fees ||
         (summaryViewModel.fees.details ?? []).length === 0

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -173,9 +173,9 @@ export class SummaryPageController extends PageController {
       /**
        * If a user does not need to pay, redirect them to /status
        */
-      if (summaryViewModel.callback?.returnUrl) {
-        return h.redirect(summaryViewModel.callback?.returnUrl);
-      }
+      // if (summaryViewModel.callback?.returnUrl) {
+      //   return h.redirect(summaryViewModel.callback?.returnUrl);
+      // }
       if (
         !summaryViewModel.fees ||
         (summaryViewModel.fees.details ?? []).length === 0


### PR DESCRIPTION
# Description

The implementation of the return URL is blocking the callback URL webhook to PUT form data. 

- The return Url redirect has been moved to after the callback urls/webhooks have run.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

