### PR TITLE
Fix allow multiple form rehydrates

### DIFF
--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -31,8 +31,12 @@ const applicationStatus = {
             const { statusService, cacheService } = request.services([]);
             const { params } = request;
             const form = server.app.forms[params.id];
+            const state = await cacheService.getState(request);
 
-            if (!!request.pre.confirmationViewModel?.confirmation) {
+            if (
+              !!request.pre.confirmationViewModel?.confirmation &&
+              !state.callback?.returnUrl
+            ) {
               request.logger.info(
                 [`/${params.id}/status`],
                 `${request.yar.id} confirmationViewModel found for user`
@@ -48,8 +52,6 @@ const applicationStatus = {
                 errorList: ["there was a problem with your payment"],
               });
             }
-
-            const state = await cacheService.getState(request);
 
             if (state?.userCompletedSummary !== true) {
               request.logger.error(

--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -73,7 +73,9 @@ const applicationStatus = {
               confirmation: viewModel,
             });
             await cacheService.clearState(request);
-
+            if (state.callback?.returnUrl) {
+              return h.redirect(state.callback?.returnUrl);
+            }
             return h.view("confirmation", viewModel);
           },
         },

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -173,9 +173,6 @@ export class SummaryPageController extends PageController {
       /**
        * If a user does not need to pay, redirect them to /status
        */
-      // if (summaryViewModel.callback?.returnUrl) {
-      //   return h.redirect(summaryViewModel.callback?.returnUrl);
-      // }
       if (
         !summaryViewModel.fees ||
         (summaryViewModel.fees.details ?? []).length === 0

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -173,9 +173,9 @@ export class SummaryPageController extends PageController {
       /**
        * If a user does not need to pay, redirect them to /status
        */
-      if (summaryViewModel.callback?.returnUrl) {
-        return h.redirect(summaryViewModel.callback?.returnUrl);
-      }
+      // if (summaryViewModel.callback?.returnUrl) {
+      //   return h.redirect(summaryViewModel.callback?.returnUrl);
+      // }
       if (
         !summaryViewModel.fees ||
         (summaryViewModel.fees.details ?? []).length === 0


### PR DESCRIPTION
Description
After a form submission the state associated to the forms session is changed to record the submission, this prevents returning to the form via the return url on form submission. It prevents a user changing the answer on their forms within the session's duration.

Now checks to see if a return Url has been specified (on subsequent requests), if so use this return url.

Type of change
Bug fix (non-breaking change which fixes an issue)