### PR TITLE
Allow save per page config on rehydration

### DIFF
--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -101,7 +101,6 @@ export class StatusService {
     const state = await this.cacheService.getState(request);
     let formData = this.webhookArgsFromState(state);
 
-    // const { outputs } = state;
     const { outputs, callback } = state;
 
     const savePerPageWebhook = outputs?.find(
@@ -110,13 +109,13 @@ export class StatusService {
 
     let response;
 
-    if (savePerPageWebhook?.outputData.url == "True") {
+    if (savePerPageWebhook?.outputData.url) {
       this.logger.info(
         ["StatusService", "savePerPageRequest"],
         `savePerPageWebhook request detected for ${request.yar.id}`
       );
       try {
-        if (callback) {
+        if (callback && savePerPageWebhook?.outputData.url == "True") {
           this.logger.info(
             ["StatusService", "outputRequests"],
             `Callback detected for ${request.yar.id} - PUT to ${callback.callbackUrl}`

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -101,28 +101,42 @@ export class StatusService {
     const state = await this.cacheService.getState(request);
     let formData = this.webhookArgsFromState(state);
 
-    const { outputs } = state;
+    // const { outputs } = state;
+    const { outputs, callback } = state;
+
     const savePerPageWebhook = outputs?.find(
       (output) => output.type === "savePerPage"
     );
 
     let response;
 
-    if (savePerPageWebhook?.outputData.url) {
+    if (savePerPageWebhook?.outputData.url == "True") {
       this.logger.info(
         ["StatusService", "savePerPageRequest"],
-        `savePerPageWebhook Url detected for ${request.yar.id}`
+        `savePerPageWebhook request detected for ${request.yar.id}`
       );
       try {
-        response = await this.webhookService.postRequest(
-          savePerPageWebhook.outputData.url,
-          formData,
-          "PUT"
-        );
-        this.logger.info(
-          ["StatusService", "savePerPageRequest"],
-          `savePerPageWebhook response: ${response}`
-        );
+        if (callback) {
+          this.logger.info(
+            ["StatusService", "outputRequests"],
+            `Callback detected for ${request.yar.id} - PUT to ${callback.callbackUrl}`
+          );
+          response = await this.webhookService.postRequest(
+            callback.callbackUrl,
+            formData,
+            "PUT"
+          );
+        } else {
+          response = await this.webhookService.postRequest(
+            savePerPageWebhook.outputData.url,
+            formData,
+            "PUT"
+          );
+          this.logger.info(
+            ["StatusService", "savePerPageRequest"],
+            `savePerPageWebhook response: ${response}`
+          );
+        }
       } catch (e) {
         this.logger.console.error(
           `Failed to save per page. savePerPageUrl: ${savePerPageWebhook?.outputData.url}`


### PR DESCRIPTION
# Description
In response to an Issue raised on: https://github.com/communitiesuk/funding-service-design-frontend/pull/99

### Problem definition
[FSD frontend](https://github.com/communitiesuk/funding-service-design-frontend) COPYs the [forms jsons ](https://github.com/communitiesuk/funding-service-design-frontend/tree/main/form_jsons/public)onto the form runner container as part of the [DOCKER file workflow](https://github.com/communitiesuk/funding-service-design-frontend/blob/main/Dockerfile#:~:text=COPY%20./form_jsons/public,config/*%20runner/config/), called in [this action](https://github.com/communitiesuk/funding-service-design-frontend/blob/077f1ed906850ef377642c38ffe8be5097a03bf1/.github/workflows/build-deploy-forms.yml#L45:~:text=push%3A%20true-,file%3A%20Dockerfile,-build%2Dargs%3A).
However the form jsons r[eferences the application store](https://github.com/communitiesuk/funding-service-design-frontend/blob/FS-1341-update-application-forms/form_jsons/public/applicant-information.json#:~:text=%22savePerPageUrl%22%3A%20%22%7B%7Bapplication_store_host%7D%7D/applications/forms%22) as an output (for safe per page functionality) .
We need to load in the correct application store host ({{application_store_host}}=127.0.0.1:5001 locally) into the forms JSON callbackUrl (for the correct env), so when they are copied into the runner, it PUTs back to the correct application store endpoint on each page save.

### Solution
The solution was to add a check for 'savePerPageWebhook == True' instead of a  savePerPage URL. If set to True we use the callbackURL provided in the rehydration payload (if available). For our use case, the savePerPage Url and callbackUrl are the same: '{{application_store_host}}/applications/forms'.