### PR TITLE
FS-1386: add regex to postcode

### DIFF
--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -38,7 +38,7 @@ export class TextField extends FormComponent {
 
     if (schema.regex) {
       const pattern = new RegExp(schema.regex);
-      componentSchema.pattern(pattern);
+      componentSchema = componentSchema.pattern(pattern);
     }
 
     if (options.customValidationMessage) {

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -42,9 +42,9 @@ export class TextField extends FormComponent {
     }
 
     if (options.customValidationMessage) {
-      componentSchema = componentSchema.messages({
-        any: options.customValidationMessage,
-      });
+      componentSchema = componentSchema.message(
+        options.customValidationMessage
+      );
     }
 
     this.formSchema = componentSchema;

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -42,9 +42,15 @@ export class TextField extends FormComponent {
     }
 
     if (options.customValidationMessage) {
-      componentSchema = componentSchema.message(
-        options.customValidationMessage
-      );
+      if (schema.regex) {
+        componentSchema = componentSchema.message(
+          options.customValidationMessage
+        );
+      } else {
+        componentSchema = componentSchema.messages({
+          any: options.customValidationMessage,
+        });
+      }
     }
 
     this.formSchema = componentSchema;

--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -54,7 +54,10 @@ export class UkAddressField extends FormComponent {
           max: 10,
           regex: "^([A-Z][A-HJ-Y]?[0-9][A-Z0-9]? ?[0-9][A-Z]{2}|GIR ?0A{2})$",
         },
-        options: { required: isRequired },
+        options: {
+          required: isRequired,
+          customValidationMessage: "Enter a valid postcode",
+        },
       },
     ];
 

--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -50,7 +50,10 @@ export class UkAddressField extends FormComponent {
         type: "TextField",
         name: "postcode",
         title: "Postcode",
-        schema: { max: 10 },
+        schema: {
+          max: 10,
+          regex: "^([A-Z][A-HJ-Y]?[0-9][A-Z0-9]? ?[0-9][A-Z]{2}|GIR ?0A{2})$",
+        },
         options: { required: isRequired },
       },
     ];

--- a/runner/test/cases/server/plugins/engine/components/TextField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/TextField.test.ts
@@ -73,12 +73,31 @@ suite("TextField", () => {
       });
 
       component = TextComponent({
-        schema: { regex: "[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}" },
+        schema: {
+          regex: "[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}",
+          min: 5,
+          max: 10,
+        },
       });
 
       expect(
         component.formSchema.validate("AJ98 7AX", { messages })
       ).to.be.equal({ value: "AJ98 7AX" });
+
+      const invalidRegexResult = component.formSchema.validate("###six");
+      expect(invalidRegexResult.error.details[0].type).to.be.equal(
+        "string.pattern.base"
+      );
+
+      const tooFewCharsResult = component.formSchema.validate("AJ98");
+      expect(tooFewCharsResult.error.details[0].type).to.be.equal("string.min");
+
+      const tooManyCharsResult = component.formSchema.validate(
+        "AJ98 7AXAJ98 7AX"
+      );
+      expect(tooManyCharsResult.error.details[0].type).to.be.equal(
+        "string.max"
+      );
     });
 
     function TextComponent(properties) {


### PR DESCRIPTION
# Description

Adds regex validation of postcode in UK address field (and fix it more widely for `textinput` fields.

![Screenshot 2022-09-09 at 15 42 59](https://user-images.githubusercontent.com/1764158/189377079-6bc1996d-30c8-443e-91f8-eddec5216890.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally on designer/runner. Tested regex using regex tester
Updated unit tests

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
