### PR TITLE
FS-1386: use case insensitive postcode regex

### DIFF
--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -52,7 +52,8 @@ export class UkAddressField extends FormComponent {
         title: "Postcode",
         schema: {
           max: 10,
-          regex: "^([A-Z][A-HJ-Y]?[0-9][A-Z0-9]? ?[0-9][A-Z]{2}|GIR ?0A{2})$",
+          regex:
+            "^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$",
         },
         options: {
           required: isRequired,


### PR DESCRIPTION
# Description

_Small follow-up to #33 fixing issue reported by @rayhan15243_ 

Change regex to be case-insensitive
 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually against regex validator e.g. https://regex101.com/r/2ZT6Of/1
(Would like to write unit tests for the UK Address Component but haven't got my environment set up for this)

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
