### PR TITLE
FS-1246: use S3 key as location/answer

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  VERSION: "0.1.3" # Manually increment this version when pushing to main
+  VERSION: "0.1.4" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -100,7 +100,7 @@ export class UploadService {
           if (typeof doc.error !== "undefined") {
             error = "Failed to upload file to server: " + doc.error;
           } else {
-            location = bucketName;
+            location = `${applicationId}/${locations[0].hapi.filename}`;
           }
         });
       }


### PR DESCRIPTION
# Description

Previously the answer for file uploads was hardcoded to the bucket name for all uploads which made it impossible to find the file later.
This changes it to match the S3 Key. It is safe currently to hardcode to the first location as we only support single file upload.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested uploads work on the form runner and are represented as expected when rendered in the application-store e.g.
```
 {
      "name": "upload-business-plan",
      "questions": [
        {
          "fields": [
            {
              "answer": "14bbb90f-1aa1-420a-a54e-5b002e33b976/1764158.jpeg",
              "key": "rFXeZo",
              "title": "Upload business plan",
              "type": "file"
            }
          ],
          "question": "Management case",
          "status": "COMPLETED"
        }
      ],
      "status": "COMPLETED"
    }
```

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
