### PR TITLE
adding summary page identifier

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,8 +521,7 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
-    state.metadata.isSummaryPageSubmit = false;
-    await cacheService.mergeState(request, { ...state });
+
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,7 +521,6 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
-    state.metadata.isSummaryPageSubmit = false;
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,6 +521,7 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
+    state.metadata.isSummaryPageSubmit = false;
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,6 +521,8 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
+    state.metadata.isSummaryPageSubmit = false;
+    await cacheService.mergeState(request, { ...state });
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,7 +521,8 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
-
+    state.metadata.isSummaryPageSubmit = false;
+    await cacheService.mergeState(request, { ...state });
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -521,14 +521,18 @@ export class PageControllerBase {
     const payload = (request.payload || {}) as FormData;
     const formResult: any = this.validateForm(payload);
     const state = await cacheService.getState(request);
-    state.metadata.isSummaryPageSubmit = false;
-    await cacheService.mergeState(request, { ...state });
     const originalFilenames = (state || {}).originalFilenames || {};
     const fileFields = this.getViewModel(formResult)
       .components.filter((component) => component.type === "FileUploadField")
       .map((component) => component.model);
     const progress = state.progress || [];
     const { num } = request.query;
+
+    if (state.metadata === undefined) {
+      state["metadata"] = {};
+    }
+    state.metadata["isSummaryPageSubmit"] = false;
+    await cacheService.mergeState(request, { ...state });
 
     // TODO:- Refactor this into a validation method
     if (hasFilesizeError) {

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -102,6 +102,7 @@ export class SummaryPageController extends PageController {
       const { payService, cacheService } = request.services([]);
       const model = this.model;
       const state = await cacheService.getState(request);
+      state.metadata.isSummaryPageSubmit = true;
       const summaryViewModel = new SummaryViewModel(
         this.title,
         model,

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -103,6 +103,7 @@ export class SummaryPageController extends PageController {
       const model = this.model;
       const state = await cacheService.getState(request);
       state.metadata.isSummaryPageSubmit = true;
+      await cacheService.mergeState(request, { ...state });
       const summaryViewModel = new SummaryViewModel(
         this.title,
         model,

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -29,8 +29,6 @@ export class SummaryPageController extends PageController {
         return this.makePostRouteHandler()(request, h);
       }
       const state = await cacheService.getState(request);
-      // state.metadata.isSummaryPageSubmit = true;
-      // await cacheService.mergeState(request, { ...state });
       const viewModel = new SummaryViewModel(this.title, model, state, request);
 
       if (viewModel.endPage) {

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -29,6 +29,8 @@ export class SummaryPageController extends PageController {
         return this.makePostRouteHandler()(request, h);
       }
       const state = await cacheService.getState(request);
+      state.metadata.isSummaryPageSubmit = true;
+      await cacheService.mergeState(request, { ...state });
       const viewModel = new SummaryViewModel(this.title, model, state, request);
 
       if (viewModel.endPage) {

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -29,8 +29,8 @@ export class SummaryPageController extends PageController {
         return this.makePostRouteHandler()(request, h);
       }
       const state = await cacheService.getState(request);
-      state.metadata.isSummaryPageSubmit = true;
-      await cacheService.mergeState(request, { ...state });
+      // state.metadata.isSummaryPageSubmit = true;
+      // await cacheService.mergeState(request, { ...state });
       const viewModel = new SummaryViewModel(this.title, model, state, request);
 
       if (viewModel.endPage) {


### PR DESCRIPTION
# Description

Application store needs to receive a confirmation from the form runner that save and continue request came from the summary page in order to mark a form as completed. As such, we need to add a field in the metadata of the form runner that sends the confirmation when this happens.