### PR TITLE
BAU: Add auth to /{form_id}/{path} POST route

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  VERSION: "0.1.13" # Manually increment this version when pushing to main
+  VERSION: "0.1.15" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -293,6 +293,11 @@ export const plugin = {
             userPathLimit: 10,
           },
         },
+        auth: config.basicAuthOn
+          ? basicAuthStrategyName
+          : jwtAuthStrategyIsActive
+          ? jwtAuthStrategyName
+          : options.auth,
         payload: {
           output: "stream",
           parse: true,

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -94,10 +94,7 @@ export const plugin = {
       server.auth.strategy(
         jwtAuthStrategyName,
         "jwt",
-        jwtStrategyOptions(
-          config.jwtAuthCookieName,
-          config.rsa256PublicKeyBase64
-        )
+        jwtStrategyOptions(config.jwtAuthCookieName)
       );
     }
 

--- a/runner/src/server/plugins/jwtAuth.ts
+++ b/runner/src/server/plugins/jwtAuth.ts
@@ -19,13 +19,6 @@ export function jwtAuthIsActivated(
 // this is normally used to look up keys from list in a multi-tenant scenario
 const keyFunc = async function (decoded) {
   const key = Buffer.from(config.rsa256PublicKeyBase64 ?? "", "base64");
-  console.log(
-    "Verifying token: '" +
-      JSON.stringify(decoded) +
-      "' with public key: '" +
-      config.rsa256PublicKeyBase64 +
-      "'"
-  );
   return { key, additional: decoded };
 };
 
@@ -51,16 +44,7 @@ const validate = async function (decoded, request, h) {
 
 // rsa256Options()
 // Returns configuration options for rsa256 auth strategy
-export function rsa256Options(jwtAuthCookieName, rsa256PublicKeyBase64) {
-  console.log(
-    "Validating jwt in cookie name '" +
-      jwtAuthCookieName +
-      "' with RSA256 base64 key '" +
-      rsa256PublicKeyBase64 +
-      "' decoded to key '" +
-      Buffer.from(rsa256PublicKeyBase64 ?? "", "base64").toString() +
-      "'"
-  );
+export function rsa256Options(jwtAuthCookieName) {
   return {
     key: keyFunc,
     validate,


### PR DESCRIPTION
### Add auth to /{forms_id}/{path} POST route
JWT auth and basic auth had only been added to the GET route for forms on the form runner. This replicates the auth requirements to the POST route

- also, removes debug logs that showed the RSA public key