### PR TITLE
Fs 1620 multitext field no longer contains if max words have been exceeded

### DIFF
--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -10,8 +10,9 @@ function inputIsOverWordCount(input, maxWords) {
    * This validation is copied from the govuk-frontend library to match their client side behaviour
    * the {@link https://github.com/alphagov/govuk-frontend/blob/e1612b13771fb7ca9a58ee85393aec94a1849335/src/govuk/components/character-count/character-count.js#L91 | govuk-frontend} library
    */
+  var maxWordCount = parseInt(maxWords);
   const wordCount = input.match(/\S+/g).length || 0;
-  return maxWords > wordCount;
+  return maxWordCount > wordCount;
 }
 
 export class MultilineTextField extends FormComponent {

--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -12,7 +12,7 @@ function inputIsOverWordCount(input, maxWords) {
    */
   var maxWordCount = parseInt(maxWords);
   const wordCount = input.match(/\S+/g).length || 0;
-  return maxWordCount > wordCount;
+  return wordCount > maxWordCount;
 }
 
 export class MultilineTextField extends FormComponent {
@@ -50,7 +50,7 @@ export class MultilineTextField extends FormComponent {
     if (maxWords ?? false) {
       this.formSchema = this.formSchema.custom((value, helpers) => {
         if (inputIsOverWordCount(value, maxWords)) {
-          helpers.error("string.maxWords");
+          return helpers.error("string.maxWords");
         }
         return value;
       }, "max words validation");


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- MultiTextField validation will now work on max words


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Create a form with a multitext field, add the max words option and exceed it. The form should not progress when hitting save and continue

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
