### PR TITLE
Fs 2195 correct table structure for add another

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -168,14 +168,10 @@ export class RepeatingSummaryPageController extends PageController {
             this.hideRowTitles ? "govuk-summary-list__key--hidden-titles" : ""
           }`,
         },
-        actions: {
-          items: [
-            {
-              href: `?removeAtIndex=${i}${view ? `&view=${view}` : ``}`,
-              text: "Remove",
-              visuallyHiddenText: title,
-            },
-          ],
+        action: {
+          href: `?removeAtIndex=${i}${view ? `&view=${view}` : ``}`,
+          text: "Remove",
+          visuallyHiddenText: title,
         },
       };
     });

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -2,60 +2,67 @@
 {% from "summary-list/macro.njk" import govukSummaryList -%}
 
 <form method="post" enctype="multipart/form-data" autocomplete="on">
-  <input type="hidden" name="crumb" value="{{crumb}}"/> 
+	<input type="hidden" name="crumb" value="{{crumb}}"/>
 
-  {% if page.isRepeatingFieldPageController and details %}  
-    {{ componentList(components) }}
-  {{ govukButton({
+	{% if page.isRepeatingFieldPageController and details %}
+		{{ componentList(components) }}
+		{{ govukButton({
     attributes: { id: "add-another"},
     classes: "govuk-button govuk-button--secondary",
     text: page.saveText
     })
   }}
-  {% if page.options.customText.samePageTitle %}
-  <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--l">{{page.options.customText.samePageTitle}}</caption>
-    <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">{{page.options.customText.columnOneTitle}}</th>
-      <th scope="col" class="govuk-table__header"><strong>{{page.options.customText.columnTwoTitle}}</strong></th>
-      <th scope="col" class="govuk-table__header"><strong>{{page.options.customText.columnThreeTitle}}</strong></th>
-    </tr>
-  </thead>
-  {{details.length}}
-    {%if not details.rows.length %}    
-      <p class="govuk-body" style="margin-top: 30px;">
-        <strong>{{page.noCostsTitle}}</strong>      
-      </p>
-      <p class="govuk-body">
-        {{page.noCostsText}}
-      </p>
-      <hr />
-    {% else %}
-      {% for row in details.rows %}
-        <tr class="govuk-table__row">      
-          <th scope="row" class="govuk-table__header">{{ row.key.text }}</th>
-          <td class="govuk-table__cell">{{ row.value.text }}</td>
-          <td class="govuk-table__cell">{{ row.action }}</td>
-        </tr>
-      {% endfor %}
-    {% endif %}
-  {% else %}
-  {{ componentList(components) }}
-  {% endif %}  
-  </table>
-  {% endif %}  
-  {% if not (components[0].type == "FlashCard") %}
-    {% if isStartPage %}
-      {{ govukButton({ attributes: { id: "submit" }, text: page.continueText}) }}
-    {% else %}
-      {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
-        {% if details.rows.length %}
-          {{ govukButton({ attributes: { id: "submit" }, text: page.saveAndContinueText, name: "next", value: "continue"}) }}
-        {% endif %}
-      {% else %}
-        {{ govukButton({ attributes: { id: "submit" }, text: page.saveAndContinueText }) }}
-      {% endif %}
-    {% endif %}
-  {% endif %}
+		{% if page.options.customText.samePageTitle %}
+			<table class="govuk-table">
+				<caption class="govuk-table__caption govuk-table__caption--m">{{page.options.customText.samePageTitle}}</caption>
+				<thead class="govuk-table__head">
+					<tr class="govuk-table__row">
+						<th scope="col" class="govuk-table__header">{{page.options.customText.columnOneTitle}}</th>
+						<th scope="col" class="govuk-table__header">
+							<strong>{{page.options.customText.columnTwoTitle}}</strong>
+						</th>
+						<th scope="col" class="govuk-table__header">
+							<strong>{{page.options.customText.columnThreeTitle}}</strong>
+						</th>
+					</tr>
+				</thead>
+				{{details.length}}
+				{% for row in details.rows %}
+					<tr class="govuk-table__row">
+						<th scope="row" class="govuk-table__header">{{ row.key.text }}</th>
+						<td class="govuk-table__cell">{{ row.value.text }}</td>
+						<td class="govuk-table__cell">
+							<a href={{row.action.href}}>{{ row.action.text }}</a>
+						</td>
+					</tr>
+				{% endfor %}
+			{% endif %}
+		</table>
+		{%if not details.rows.length %}
+			<tr class="govuk-table__row">
+				<p class="govuk-body" style="margin-top: 30px;">
+					<strong>{{page.noCostsTitle}}</strong>
+				</p>
+				<p class="govuk-body">
+					{{page.noCostsText}}
+				</p>
+				<hr/>
+			</tr>
+		{% endif %}
+	{% else %}
+		{{ componentList(components) }}
+	{% endif %}
+	{% if not (components[0].type == "FlashCard") %}
+		{% if isStartPage %}
+			{{ govukButton({ attributes: { id: "submit" }, text: page.continueText}) }}
+		{% else %}
+			{% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
+				{% if details.rows.length %}
+					{{ govukButton({ attributes: { id: "submit" }, text: page.saveAndContinueText, name: "next", value: "continue"}) }}
+				{% endif %}
+			{% else %}
+				{{ govukButton({ attributes: { id: "submit" }, text: page.saveAndContinueText }) }}
+			{% endif %}
+		{% endif %}
+	{% endif %}
 </form>

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -13,40 +13,38 @@
     })
   }}
   {% if page.options.customText.samePageTitle %}
-  <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="event-name">
-    {{page.options.customText.samePageTitle}}
-  </label>
-  </h1>
-  {% endif %}
-  <dl class="govuk-summary-list" style="margin-bottom: 0;">      
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-       {{page.options.customText.columnOneTitle}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <strong>{{page.options.customText.columnTwoTitle}}</strong>
-      </dd>        
-        <dd class="govuk-summary-list__actions">           
-            <strong>{{page.options.customText.columnThreeTitle}}</strong>            
-        </dd>        
-    </div>  
-  </dl>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--l">{{page.options.customText.samePageTitle}}</caption>
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">{{page.options.customText.columnOneTitle}}</th>
+      <th scope="col" class="govuk-table__header"><strong>{{page.options.customText.columnTwoTitle}}</strong></th>
+      <th scope="col" class="govuk-table__header"><strong>{{page.options.customText.columnThreeTitle}}</strong></th>
+    </tr>
+  </thead>
   {{details.length}}
     {%if not details.rows.length %}    
-    <p class="govuk-body" style="margin-top: 30px;">
-      <strong>{{page.noCostsTitle}}</strong>      
-    </p>
-    <p class="govuk-body">
-      {{page.noCostsText}}
-    </p>
-    <hr />
+      <p class="govuk-body" style="margin-top: 30px;">
+        <strong>{{page.noCostsTitle}}</strong>      
+      </p>
+      <p class="govuk-body">
+        {{page.noCostsText}}
+      </p>
+      <hr />
     {% else %}
-    {{ govukSummaryList(details) }}
+      {% for row in details.rows %}
+        <tr class="govuk-table__row">      
+          <th scope="row" class="govuk-table__header">{{ row.key.text }}</th>
+          <td class="govuk-table__cell">{{ row.value.text }}</td>
+          <td class="govuk-table__cell">{{ row.action }}</td>
+        </tr>
+      {% endfor %}
     {% endif %}
   {% else %}
   {{ componentList(components) }}
   {% endif %}  
-
+  </table>
+  {% endif %}  
   {% if not (components[0].type == "FlashCard") %}
     {% if isStartPage %}
       {{ govukButton({ attributes: { id: "submit" }, text: page.continueText}) }}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Changed the add another view to use a table rather than a summary list. Also change the data structure slightly for the passed in actions (seemed and but pointless to have them in an array).


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Go to an add another page, functionality still should work the same.

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [x] I have checked deployments are working in all environments
