### PR TITLE
FS-2193: Allow html in hint when hideTitle is true

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  VERSION: "0.1.36" # Manually increment this version when pushing to main
+  VERSION: "0.1.37" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -96,8 +96,8 @@ export class MultilineTextField extends FormComponent {
       viewModel.maxwords = options.maxWords;
     }
     if (options.hideTitle) {
-      viewModel.label = { text: viewModel.hint?.html!, classes: "" };
-      viewModel.hint = { html: "" };
+      viewModel.label = { text: "", html: viewModel.hint?.html!, classes: "" };
+      viewModel.hint = undefined;
     }
     return viewModel;
   }

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -80,8 +80,8 @@ export class TextField extends FormComponent {
     }
 
     if (options.hideTitle) {
-      viewModel.label = { text: viewModel.hint?.html!, classes: "" };
-      viewModel.hint = { html: "" };
+      viewModel.label = { text: "", html: viewModel.hint?.html!, classes: "" };
+      viewModel.hint = undefined;
     }
 
     return viewModel;


### PR DESCRIPTION
### Description

-  Allow html in hint when hideTitle is true
-  Also set hint to undefined instead of an empty string, this prevents the empty html element from appearing on the page

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - (breaking change as any instances with `hideTitle` & html in `hint` will now render the html, [no occurrences of this exist as the `hideTitle` functionality was newly implemented in #102])

### How has this been tested?

This code change has been manually tested via the form runner on a local dev environment.
The corresponding form changes have been migrated via a script seen here with test coverage: ..todo

### Checklist

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts