### PR TITLE
FS-2242 Fixing add another colon issues

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  VERSION: "0.1.35" # Manually increment this version when pushing to main
+  VERSION: "0.1.36" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -304,7 +304,7 @@ export class RepeatingFieldPageController extends PageController {
         const amount = answers[i].match(regex)[2];
         const description = answers[i].match(regex)[1];
         answers[i] = {
-          "type-of-revenue-cost": description.trim(),
+          "type-of-revenue-cost": description,
           value: amount,
         };
       }

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -296,7 +296,7 @@ export class RepeatingFieldPageController extends PageController {
     }
 
     // The function uses the match method to extract the description and amount from the string using the regular expression.
-    // Everything before the : is the description and after : £ is te amount
+    // Everything before the : is the description and after : £ is the amount
     const regex = /(.+) : £(.+)$/;
     for (let i = 0; i < answers.length; i++) {
       if (typeof answers[i] === "string") {

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -297,7 +297,7 @@ export class RepeatingFieldPageController extends PageController {
 
     for (let i = 0; i < answers.length; i++) {
       if (typeof answers[i] === "string") {
-        // TODO: This is a javascript right join, we need to have a re-think about how add another answers work
+        // TODO: This is a javascript right split, we need to have a re-think about how add another answers work
         const reversedAnswer = answers[i].split("").reverse().join("");
         const values = reversedAnswer.split(" : ");
         const amount = values.shift().split("").reverse().join("");

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -297,12 +297,15 @@ export class RepeatingFieldPageController extends PageController {
 
     for (let i = 0; i < answers.length; i++) {
       if (typeof answers[i] === "string") {
-        const values = answers[i].split(":");
-        let multiInput = {
-          "type-of-revenue-cost": values[0].trim(),
-          value: values[1].substring(2),
+        // TODO: This is a javascript right join, we need to have a re-think about how add another answers work
+        const reversedAnswer = answers[i].split("").reverse().join("");
+        const values = reversedAnswer.split(" : ");
+        const amount = values.shift().split("").reverse().join("");
+        const description = values.join(" : ").split("").reverse().join("");
+        answers[i] = {
+          "type-of-revenue-cost": description.trim(),
+          value: amount.substring(1),
         };
-        answers[i] = multiInput;
       }
     }
     return answers;

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -300,11 +300,11 @@ export class RepeatingFieldPageController extends PageController {
         // TODO: This is a javascript right split, we need to have a re-think about how add another answers work
         const reversedAnswer = answers[i].split("").reverse().join("");
         const values = reversedAnswer.split(" : ");
-        const amount = values.shift().split("").reverse().join("");
+        const amount = values.shift().split("£").reverse().join("");
         const description = values.join(" : ").split("").reverse().join("");
         answers[i] = {
           "type-of-revenue-cost": description.trim(),
-          value: amount.substring(1),
+          value: amount,
         };
       }
     }

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -295,13 +295,14 @@ export class RepeatingFieldPageController extends PageController {
       return answers;
     }
 
+    // The function uses the match method to extract the description and amount from the string using the regular expression.
+    // Everything before the : is the description and after : £ is te amount
+    const regex = /(.+) : £(.+)$/;
     for (let i = 0; i < answers.length; i++) {
       if (typeof answers[i] === "string") {
-        // TODO: This is a javascript right split, we need to have a re-think about how add another answers work
-        const reversedAnswer = answers[i].split("").reverse().join("");
-        const values = reversedAnswer.split(" : ");
-        const amount = values.shift().split("£").reverse().join("");
-        const description = values.join(" : ").split("").reverse().join("");
+        // TODO: We need to have a re-think about how add another answers work
+        const amount = answers[i].match(regex)[2];
+        const description = answers[i].match(regex)[1];
         answers[i] = {
           "type-of-revenue-cost": description.trim(),
           value: amount,

--- a/runner/src/server/plugins/engine/pageControllers/index.ts
+++ b/runner/src/server/plugins/engine/pageControllers/index.ts
@@ -5,4 +5,5 @@ export { StartDatePageController } from "./StartDatePageController";
 export { StartPageController } from "./StartPageController";
 export { SummaryPageController } from "./SummaryPageController";
 export { PageControllerBase } from "./PageControllerBase";
+export { RepeatingFieldPageController } from "./RepeatingFieldPageController";
 export { getPageController, controllerNameFromPath } from "./helpers";

--- a/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
@@ -9,8 +9,8 @@ exports.lab = lab;
 const { expect } = Code;
 const { suite, test } = lab;
 
-suite("PageControllerBase", () => {
-  test("getErrors correctly parses ISO string to readable string", () => {
+suite("RepeatingFieldPageController", () => {
+  test("convert answers to string", () => {
     const def = {
       title: "This is a test",
       path: "/first-page",

--- a/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
@@ -15,7 +15,20 @@ suite("PageControllerBase", () => {
       title: "This is a test",
       path: "/first-page",
       name: "",
-      components: [],
+      components: [
+        {
+          name: "MultiInputField",
+          options: {
+            prefix: "£",
+            textFieldTitle: "Type of Revenue Cost",
+            numberFieldTitle: "Amount",
+          },
+          type: "MultiInputField",
+          title: "MultiInputField",
+          hint: "The MultiInputField needed",
+          schema: {},
+        },
+      ],
       next: [
         {
           path: "/second-page",
@@ -38,10 +51,10 @@ suite("PageControllerBase", () => {
     );
 
     const expected = [
-      { "type-of-revenue-cost": "ABC : def", value: "£20002" },
-      { "type-of-revenue-cost": "https://www.google.com", value: "£10552" },
-      { "type-of-revenue-cost": "Town Funding", value: "£52" },
-      { "type-of-revenue-cost": "This is a, test", value: "£8481" },
+      { "type-of-revenue-cost": "ABC : def", value: "20002" },
+      { "type-of-revenue-cost": "https://www.google.com", value: "10552" },
+      { "type-of-revenue-cost": "Town Funding", value: "52" },
+      { "type-of-revenue-cost": "This is a, test", value: "8481" },
     ];
 
     const result = controller.convertMultiInputStringAnswers([

--- a/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
@@ -1,0 +1,56 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+
+import { RepeatingFieldPageController } from "server/plugins/engine/pageControllers";
+import { FormModel } from "src/server/plugins/engine/models/FormModel";
+
+const lab = Lab.script();
+exports.lab = lab;
+const { expect } = Code;
+const { suite, test } = lab;
+
+suite("PageControllerBase", () => {
+  test("getErrors correctly parses ISO string to readable string", () => {
+    const def = {
+      title: "This is a test",
+      path: "/first-page",
+      name: "",
+      components: [],
+      next: [
+        {
+          path: "/second-page",
+        },
+      ],
+    };
+
+    const controller = new RepeatingFieldPageController(
+      new FormModel(
+        {
+          pages: [],
+          startPage: "/start",
+          sections: [],
+          lists: [],
+          conditions: [],
+        },
+        {}
+      ),
+      def
+    );
+
+    const expected = [
+      { "type-of-revenue-cost": "ABC : def", value: "£20002" },
+      { "type-of-revenue-cost": "https://www.google.com", value: "£10552" },
+      { "type-of-revenue-cost": "Town Funding", value: "£52" },
+      { "type-of-revenue-cost": "This is a, test", value: "£8481" },
+    ];
+
+    const result = controller.convertMultiInputStringAnswers([
+      "ABC : def : £20002",
+      "https://www.google.com : £10552",
+      "Town Funding : £52",
+      "This is a, test : £8481",
+    ]);
+
+    expect(result).to.equal(expected);
+  });
+});

--- a/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/pageControllers/RepeatingFieldPageController.test.ts
@@ -10,7 +10,7 @@ const { expect } = Code;
 const { suite, test } = lab;
 
 suite("RepeatingFieldPageController", () => {
-  test("convert answers to string", () => {
+  test("convertMultiInputStringAnswers", () => {
     const def = {
       title: "This is a test",
       path: "/first-page",


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Add another was causing loss of data when a users added a description field with a colon in it. This is a quick fix to avoid this. Add another needs a rework


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

return to and application with an colon within the revenue cost field 

eg.
`questions": [
        {
            "question": "First page",
            "fields": [
                {
                    "key": "MultiInputField",
                    "title": "MultiInputField",
                    "type": "text",
                    "answer": [
                        "asdasd : asdasd : £1223"
                    ]
                }
            ]
        }
    ]`

# Checklist:

- [x] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
