### PR TITLE
Fix for passing form_session_identifier

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  VERSION: "0.1.43" # Manually increment this version when pushing to main
+  VERSION: "0.1.44" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -18,7 +18,11 @@ export function proceed(
   }
 
   if (typeof returnUrl === "string" && returnUrl.startsWith("/")) {
-    return h.redirect(`${returnUrl}${form_session_identifier}`);
+    const parsedUrl = new URL(returnUrl);
+    if (request.query.form_session_identifier) {
+        parsedUrl.searchParams.append('form_session_identifier', request.query.form_session_identifier);
+    }
+    return h.redirect(parsedUrl.toString());
   } else {
     return redirectTo(request, h, nextUrl);
   }

--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -11,9 +11,14 @@ export function proceed(
   nextUrl: string
 ) {
   const returnUrl = request.query.returnUrl;
+  let form_session_identifier = "";
+
+  if (request.query.form_session_identifier) {
+    form_session_identifier = `?form_session_identifier=${request.query.form_session_identifier}`;
+  }
 
   if (typeof returnUrl === "string" && returnUrl.startsWith("/")) {
-    return h.redirect(returnUrl);
+    return h.redirect(`${returnUrl}${form_session_identifier}`);
   } else {
     return redirectTo(request, h, nextUrl);
   }

--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -18,11 +18,7 @@ export function proceed(
   }
 
   if (typeof returnUrl === "string" && returnUrl.startsWith("/")) {
-    const parsedUrl = new URL(returnUrl);
-    if (request.query.form_session_identifier) {
-        parsedUrl.searchParams.append('form_session_identifier', request.query.form_session_identifier);
-    }
-    return h.redirect(parsedUrl.toString());
+    return h.redirect(`${returnUrl}${form_session_identifier}`);
   } else {
     return redirectTo(request, h, nextUrl);
   }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Form session identifier wasnt being used as part of the return url cause on change to break

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Go through a form with multiple pages
- [ ] Get all the way to the summary
- [ ] Click change on a section
- [ ] This shouldn't change to not supplied and should have correct data


# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
