### PR TITLE
bau-remove-auto-action-trigger

### DIFF
--- a/.github/workflows/dluhc-build-and-deploy-with-forms.yml
+++ b/.github/workflows/dluhc-build-and-deploy-with-forms.yml
@@ -5,7 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
 
 env:
   DOCKER_REGISTRY: ghcr.io


### PR DESCRIPTION
Remove the auto trigger so that publishing a new docker image (with forms) is a manual step.
