### PR TITLE
FS-2538: Multiple fixes to FreeTextField

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.48" # Manually increment this version when pushing to main
+  VERSION: "0.1.49" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/components/FreeTextField.ts
+++ b/runner/src/server/plugins/engine/components/FreeTextField.ts
@@ -13,8 +13,8 @@ function inputIsOverWordCount(input, maxWords) {
    */
   // This peice of regex will remove all the html elements and entitys to get a accurate word count
   input = input.replace(/<[^>]*>/g, "").replace(/&[^;]+;/g, "");
-  var maxWordCount = parseInt(maxWords);
-  const wordCount = input.match(/\S+/g).length || 0;
+  const maxWordCount = parseInt(maxWords);
+  const wordCount = (input.match(/\S+/g) || []).length;
   return wordCount > maxWordCount;
 }
 

--- a/runner/src/server/plugins/engine/components/FreeTextField.ts
+++ b/runner/src/server/plugins/engine/components/FreeTextField.ts
@@ -54,7 +54,7 @@ export class FreeTextField extends FormComponent {
     if (maxWords ?? false) {
       this.formSchema = this.formSchema.custom((value, helpers) => {
         if (inputIsOverWordCount(value, maxWords)) {
-          return helpers.error("string.maxWords");
+          return helpers.error("string.maxWords", { limit: maxWords });
         }
         return value;
       }, "max words validation");
@@ -98,7 +98,7 @@ export class FreeTextField extends FormComponent {
     }
 
     if (options.maxWords ?? false) {
-      viewModel.maxwords = options.maxWords;
+      viewModel.maxWords = options.maxWords;
     }
     if (options.hideTitle) {
       viewModel.label = { text: "", html: viewModel.hint?.html!, classes: "" };

--- a/runner/src/server/plugins/engine/components/FreeTextField.ts
+++ b/runner/src/server/plugins/engine/components/FreeTextField.ts
@@ -6,6 +6,8 @@ import { FormModel } from "server/plugins/engine/models";
 import { FreeTextFieldViewModel } from "server/plugins/engine/components/types";
 import { DataType } from "./types";
 
+// this must match the front-end, or we'll have discrepancies
+// runner\src\server\plugins\engine\views\components\freetextfield.html
 function inputIsOverWordCount(input, maxWords) {
   /**
    * This validation is copied from the govuk-frontend library to match their client side behaviour

--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -50,7 +50,7 @@ export class MultilineTextField extends FormComponent {
     if (maxWords ?? false) {
       this.formSchema = this.formSchema.custom((value, helpers) => {
         if (inputIsOverWordCount(value, maxWords)) {
-          return helpers.error("string.maxWords");
+          return helpers.error("string.maxWords", { limit: maxWords });
         }
         return value;
       }, "max words validation");

--- a/runner/src/server/plugins/engine/components/types.ts
+++ b/runner/src/server/plugins/engine/components/types.ts
@@ -77,7 +77,7 @@ export type ComponentCollectionViewModel = {
 export type FreeTextFieldViewModel = {
   maxlength?: number;
   isCharacterOrWordCount: boolean;
-  maxwords?: number;
+  maxWords?: number;
 } & ViewModel;
 
 export type DataType =

--- a/runner/src/server/plugins/engine/views/components/freetextfield.html
+++ b/runner/src/server/plugins/engine/views/components/freetextfield.html
@@ -36,17 +36,12 @@
       contextmenu: 'paste'
     });
 
+    // this must match the back-end, or we'll have discrepancies
+    // runner\src\server\plugins\engine\components\FreeTextField.ts
     function countWords(editor) {
-      var content = editor.getContent({ format: 'text' });
-      // removing line breaks ast they were sometimes counting as words
-      var noLineBreaksContent = content.replace(/(\r\n|\n|\r)/gm, " ");
-      var wordCount = 0;
-
-      if (content) {
-        // Regex for checking white space border and not counting special characters
-        var matches = noLineBreaksContent.match(/\b\w+\b/g);
-        wordCount = matches ? matches.length : 0;
-      }
+      let content = editor.getContent()
+      content = content.replace(/<[^>]*>/g, "").replace(/&[^;]+;/g, "");
+      const wordCount = (content.match(/\S+/g) || []).length;
       return wordCount;
     }
 

--- a/runner/src/server/plugins/engine/views/components/freetextfield.html
+++ b/runner/src/server/plugins/engine/views/components/freetextfield.html
@@ -1,16 +1,14 @@
 {% macro FreeTextField(component) %}
 
 <head>
-  <script src="/assets/tinymce.min.js"></script>
   <script type="text/javascript">
-
     tinymce.init({
       setup: function (editor) {
         editor.on('init input setcontent change', function () {          
           setWordCount(editor);
         });       
       },
-      selector: '.myeditablediv',
+      selector: '#{{ component.model.id }}',
       skin: 'tinymce-5',
       branding: false,
       elementpath: false,
@@ -18,7 +16,7 @@
       height: 150,
       menubar: false,
       browser_spellcheck: true,
-      max_words: Number('{{ component.model.maxwords }}'),
+      max_words: Number('{{ component.model.maxWords }}'),
       iframe_aria_text: '{{ component.model.name }}',
       paste_data_images: false,
       dragover_callback: function (e) {
@@ -85,10 +83,10 @@
   </span>
   {% endif %}
   <textarea id="{{ component.model.id }}" name="{{ component.model.name }}" rows="5"
-    class="govuk-textarea myeditablediv">{{ component.model.value }}</textarea>
+    class="govuk-textarea">{{ component.model.value }}</textarea>
   {% if component.model.isCharacterOrWordCount == true %}
   <div id="word-count-label-{{ component.model.id }}" class="govuk-hint govuk-js-character-count">You can enter up to {{
-    component.model.maxwords }} words</div>
+    component.model.maxWords }} words</div>
   {% endif %}
 </div>
 

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -67,6 +67,7 @@
   <!-- End Matomo Code -->
 
   <script src="{{ assetPath }}/accessible-autocomplete.min.js"></script>
+  <script src="{{ assetPath }}/tinymce.min.js"></script>
 {% endblock %}
 
 {% block pageTitle %}


### PR DESCRIPTION
# Description

- Change tinymce selectors to be each unique component, this allows us to use multiple on the same form without affecting one another
- Move the import of tinymce to layout.html, this means we'll only import it once, rather than for each time the component is rendered, this was breaking functionality
- Add limit context to error messages, so the strings display properly with the number inside of them, also fixed for MultilineTextField

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
