### PR TITLE
Footers are now customizable

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.53" # Manually increment this version when pushing to main
+  VERSION: "0.1.54" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -143,6 +143,11 @@ export type Fee = {
   prefix?: string;
 };
 
+export type Footer = {
+  href: string;
+  text: string;
+};
+
 /**
  * `FormDefinition` is a typescript representation of `Schema`
  */
@@ -164,4 +169,5 @@ export type FormDefinition = {
   specialPages?: SpecialPages;
   paymentReferenceFormat?: string;
   backLinkText?: string;
+  footer?: Footer;
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -230,6 +230,11 @@ const phaseBannerSchema = joi.object().keys({
   phase: joi.string().valid("alpha", "beta"),
 });
 
+const footerSchema = joi.object().keys({
+  href: joi.string(),
+  text: joi.string(),
+});
+
 export const Schema = joi
   .object()
   .required()
@@ -252,6 +257,7 @@ export const Schema = joi
     phaseBanner: phaseBannerSchema,
     specialPages: specialPagesSchema.optional(),
     backLinkText: joi.string().allow("").optional(),
+    footer: joi.array().items(footerSchema).optional(),
   });
 
 /**

--- a/runner/src/server/forms/report-a-terrorist.json
+++ b/runner/src/server/forms/report-a-terrorist.json
@@ -285,5 +285,23 @@
         ]
       }
     }
+  ],
+  "footer": [
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Privacy test"
+    },
+    {
+      "href": "https://www.google.com",
+      "text": "Cookies test"
+    },
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Accessibility Statement test"
+    },
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Contact Us test"
+    }
   ]
 }

--- a/runner/src/server/forms/test.json
+++ b/runner/src/server/forms/test.json
@@ -481,7 +481,7 @@
       "title": "Update form in application store",
       "type": "savePerPage",
       "outputConfiguration": {
-        "savePerPageUrl": "https://webhook.site/ba83e49b-cdd1-46e9-9c04-c89cfa651752"
+        "savePerPageUrl": "True"
       }
     }
   ],
@@ -512,6 +512,24 @@
       "name": "moreThanThreeApplicants",
       "displayName": "moreThanThreeApplicants",
       "value": "applicantDetails.numberOfApplicants > 3"
+    }
+  ],
+  "footer": [
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Privacy"
+    },
+    {
+      "href": "https://www.google.com",
+      "text": "The is a test"
+    },
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Accessibility Statement"
+    },
+    {
+      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
+      "text": "Contact Us"
     }
   ]
 }

--- a/runner/src/server/forms/test.json
+++ b/runner/src/server/forms/test.json
@@ -513,23 +513,5 @@
       "displayName": "moreThanThreeApplicants",
       "value": "applicantDetails.numberOfApplicants > 3"
     }
-  ],
-  "footer": [
-    {
-      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
-      "text": "Privacy"
-    },
-    {
-      "href": "https://www.google.com",
-      "text": "The is a test"
-    },
-    {
-      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
-      "text": "Accessibility Statement"
-    },
-    {
-      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
-      "text": "Contact Us"
-    }
   ]
 }

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -170,12 +170,28 @@
 
 {% block footer %}
   {% set footerItems = [] %}
-  {% for footerItem in page.def.footer %}
-    {% set _ = footerItems.push({
-      href: footerItem.href,
-      text: footerItem.text
-    }) %}
-  {% endfor %}
+  {% if page.def.footer %}
+    {% for footerItem in page.def.footer %}
+      {% set _ = footerItems.push({
+        href: footerItem.href,
+        text: footerItem.text
+      }) %}
+    {% endfor %}  
+  {% else %}
+  {% set footerItems = [{
+        href: 'https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice',
+        text: 'Privacy'
+    }, {
+        href: cookiePolicyUrl,
+        text: 'Cookies'
+    }, {
+        href: accessibilityStatementUrl,
+        text: 'Accessibility Statement'
+    }, {
+        href: contactUsUrl,
+        text: 'Contact Us'
+    }]%}
+  {% endif %}
   {{ govukFooter({
     meta: {
       items: footerItems

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -169,21 +169,16 @@
 
 
 {% block footer %}
-    {{ govukFooter({
-        meta: {
-            items: [{
-                href: 'https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice',
-                text: 'Privacy'
-            }, {
-                href: cookiePolicyUrl,
-                text: 'Cookies'
-            }, {
-                href: accessibilityStatementUrl,
-                text: 'Accessibility Statement'
-            }, {
-                href: contactUsUrl,
-                text: 'Contact Us'
-            }]
-        }
-    }) }}
+  {% set footerItems = [] %}
+  {% for footerItem in page.def.footer %}
+    {% set _ = footerItems.push({
+      href: footerItem.href,
+      text: footerItem.text
+    }) %}
+  {% endfor %}
+  {{ govukFooter({
+    meta: {
+      items: footerItems
+    }
+  }) }}
 {% endblock %}

--- a/smoke-tests/designer/features/completeAForm.feature
+++ b/smoke-tests/designer/features/completeAForm.feature
@@ -27,6 +27,10 @@ Feature: Complete a form
     Given I am at the start of the "runner components test" form
     When I complete the form
     Then the Summary page is displayed with my answers
+  
+  Scenario: The footer and links are visible on start page
+    Given I am at the start of the "report a terrorist" form
+    Then I can see the footer at the bottom of the page
 
  Scenario: Back link is displayed
     Given I am at the start of the "report a terrorist" form

--- a/smoke-tests/designer/features/pageobjects/pages/formRunner.page.js
+++ b/smoke-tests/designer/features/pageobjects/pages/formRunner.page.js
@@ -13,6 +13,10 @@ class FormRunnerPage extends Page {
     return browser.$("h1");
   }
 
+  get govFooter() {
+    return browser.$("footer");
+  }
+
   /**
    * Locates the index of a checkbox by label name
    * @param labelText

--- a/smoke-tests/designer/features/steps/completeAForm.steps.js
+++ b/smoke-tests/designer/features/steps/completeAForm.steps.js
@@ -82,3 +82,11 @@ Then(/^the Summary page is displayed with my answers$/, function () {
     "testing@example.com"
   );
 });
+
+Then("I can see the footer at the bottom of the page", function () {
+  let footer = formRunner.govFooter;
+  expect(footer).toHaveTextContaining("Privacy test");
+  expect(footer).toHaveTextContaining("Cookies test");
+  expect(footer).toHaveTextContaining("Accessibility Statement test");
+  expect(footer).toHaveTextContaining("Contact Us test");
+});


### PR DESCRIPTION
# Description

- Can now customise footer with the new footer array with the form.

```
"footer": [
    {
      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
      "text": "Privacy test"
    },
    {
      "href": "https://www.google.com",
      "text": "Cookies test"
    },
    {
      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
      "text": "Accessibility Statement test"
    },
    {
      "href": "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice",
      "text": "Contact Us test"
    }
  ]

```
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Add a the new footer array to a json form
- [ ] navigate to that form and see the changes take effect

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
