### PR TITLE
FS-2421: Client side upload auth & forms

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.55" # Manually increment this version when pushing to main
+  VERSION: "0.1.56" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/fsd_config/form_jsons/cof_r2/cy/cefnogaeth-leol.json
+++ b/fsd_config/form_jsons/cof_r2/cy/cefnogaeth-leol.json
@@ -59,9 +59,16 @@
         {
           "name": "EEBFao",
           "options": {
-            "required": false
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 0
           },
-          "type": "FileUploadField",
+          "type": "ClientSideFileUploadField",
           "title": "Lanlwythwch dystiolaeth ategol ",
           "hint": "Dylai fod yn ffeil unigol nad yw'n fwy na 5MB ar unrhyw un o'r fformatau canlynol:\n\n\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m govuk-!-padding-top-3\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul>\n"
         }

--- a/fsd_config/form_jsons/cof_r2/cy/gwybodaeth-am-yr-ased.json
+++ b/fsd_config/form_jsons/cof_r2/cy/gwybodaeth-am-yr-ased.json
@@ -328,9 +328,16 @@
         {
           "name": "ArVrka",
           "options": {
-            "required": true
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
           },
-          "type": "FileUploadField",
+          "type": "ClientSideFileUploadField",
           "hint": "<label>Lanlwythwch dystiolaeth ategol i grynhoi:</label>\n<p>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>y risg y mae'r ased yn ei hwynebu</li>\n<li>na fydd unrhyw wasanaethau statudol yn cael eu trosglwyddo o'r awdurdod cyhoeddus</li>\n<li>y bydd yr ased yn gynaliadwy ar ôl iddo gael ei drosglwyddo</li>\n</ul>\n\n<label class=\"govuk-caption-m\">Er enghraifft, gall y dystiolaeth hon gynnwys cadarnhad gan y perchennog cyhoeddus neu lythyr gan yr awdurdod lleol</label>\n<p>Dylai fod yn ffeil unigol nad yw'n fwy na 5MB ar unrhyw un o'r fformatau canlynol:</p>\n\n\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul>\n</p>",
           "title": "Lanlwythwch dystiolaeth ategol"
         }

--- a/fsd_config/form_jsons/cof_r2/cy/lanlwythwch-y-cynllun-busnes.json
+++ b/fsd_config/form_jsons/cof_r2/cy/lanlwythwch-y-cynllun-busnes.json
@@ -48,8 +48,17 @@
         },
         {
           "name": "rFXeZo",
-          "options": {},
-          "type": "FileUploadField",
+          "options": {
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
+          },
+          "type": "ClientSideFileUploadField",
           "title": "Lanlwythwch y cynllun busnes",
           "hint": ""
         }

--- a/fsd_config/form_jsons/cof_r2/cy/risg.json
+++ b/fsd_config/form_jsons/cof_r2/cy/risg.json
@@ -22,8 +22,17 @@
         },
         {
           "name": "ozgwXq",
-          "options": {},
-          "type": "FileUploadField",
+          "options": {
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
+          },
+          "type": "ClientSideFileUploadField",
           "hint": "<div class=\"govuk-caption-m\">\n<p>Dylai fod yn ffeil unigol nad yw'n fwy na 5MB ar unrhyw un o'r fformatau canlynol:</p>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul> \n\n<p>Lanlwythwch ddogfen sy'n nodi manylion unrhyw risgiau y gallai eich prosiect eu hwynebu.</p>\n<label >Dylech gynnwys:</label>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m govuk-!-padding-top-3\">\n<li>disgrifiad o'r risg</li>\n<li>y tebygolrwydd y bydd yn digwydd</li>\n<li>pa bryd y gallai ddigwydd</li>\n<li>sut y bwriadwch liniaru'r risg</li>\n<li>y tebygolrwydd y bydd yn digwydd ar ôl lliniaru</li>\n</ul>\n\n<p>Peidiwch â chynnwys unrhyw risgiau i'r ased na pham y gallai gau; gwnaethom eich holi ynglŷn â hyn yn gynharach yn eich cais.</p>\n</div>\n\n<h2 class=\"govuk-heading-s\">Lanlwythwch y ddogfen risg</h2>",
           "title": "Risgiau i'ch prosiect (lanlwytho dogfen)"
         }

--- a/fsd_config/form_jsons/cof_r2/en/asset-information.json
+++ b/fsd_config/form_jsons/cof_r2/en/asset-information.json
@@ -314,9 +314,16 @@
         {
           "name": "ArVrka",
           "options": {
-            "required": true
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
           },
-          "type": "FileUploadField",
+          "type": "ClientSideFileUploadField",
           "hint": "<label>Upload supporting evidence to summarise:</label>\n<p>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>the risk the asset is facing</li>\n<li>that any statutory services will not be transferred from the public authority</li>\n<li>that the asset will be sustainable after it has been transferred</li>\n</ul>\n\n<label class=\"govuk-caption-m\">For example, this evidence can include confirmation from the public owner or a letter from the local authority.</label>\n<p>It should be a single file no bigger than 5MB in any of the following formats:</p>\n\n\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul>\n</p>",
           "title": "Upload supporting evidence"
         }

--- a/fsd_config/form_jsons/cof_r2/en/local-support.json
+++ b/fsd_config/form_jsons/cof_r2/en/local-support.json
@@ -57,9 +57,16 @@
         {
           "name": "EEBFao",
           "options": {
-            "required": false
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 0
           },
-          "type": "FileUploadField",
+          "type": "ClientSideFileUploadField",
           "title": "Upload supporting evidence",
           "hint": "It should be a single file no bigger than 5MB in any of the following formats:\n\n\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m govuk-!-padding-top-3\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul>\n"
         }

--- a/fsd_config/form_jsons/cof_r2/en/risk.json
+++ b/fsd_config/form_jsons/cof_r2/en/risk.json
@@ -22,8 +22,17 @@
         },
         {
           "name": "ozgwXq",
-          "options": {},
-          "type": "FileUploadField",
+          "options": {
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
+          },
+          "type": "ClientSideFileUploadField",
           "hint": "<div class=\"govuk-caption-m\">\n<p>It should be a single file no bigger than 5MB in any of the following formats:</p>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m\">\n<li>jpg</li>\n<li>jpeg</li>\n<li>png</li>\n<li>pdf</li>\n<li>txt</li>\n<li>doc</li>\n<li>docx</li>\n<li>odt</li>\n<li>csv</li>\n<li>xls</li>\n<li>xlsx</li>\n<li>ods</li>\n</ul> \n\n<p>Upload a document detailing any risks your project may face.</p>\n<label >You should include:</label>\n<ul class=\"govuk-list govuk-list--bullet govuk-caption-m govuk-!-padding-top-3\">\n<li>a description of the risk</li>\n<li>the likelihood of it happening</li>\n<li>when it may occur</li>\n<li>how you intend to mitigate it</li>\n<li>the likelihood of it happening after mitigation</li>\n</ul>\n\n<p>Do not include any risks to the asset or why it may close, which we asked you about earlier in your application.</p>\n</div>\n\n<h2 class=\"govuk-heading-s\">Upload risk document</h2>",
           "title": "Risks to your project (document upload)"
         }

--- a/fsd_config/form_jsons/cof_r2/en/upload-business-plan.json
+++ b/fsd_config/form_jsons/cof_r2/en/upload-business-plan.json
@@ -48,8 +48,17 @@
         },
         {
           "name": "rFXeZo",
-          "options": {},
-          "type": "FileUploadField",
+          "options": {
+            "dropzoneConfig": {
+              "maxFiles": 1,
+              "parallelUploads": 1,
+              "maxFilesize": 5,
+              "acceptedFiles": "image/jpeg,image/png,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+            },
+            "showNoScriptWarning": false,
+            "minimumRequiredFiles": 1
+          },
+          "type": "ClientSideFileUploadField",
           "title": "Upload business plan",
           "hint": ""
         }

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -167,10 +167,15 @@ async function createServer(routeConfig: RouteConfig) {
   await server.register(pluginViews);
   await server.register(HapiBasicAuth);
   await server.register(HapiJwtAuth2);
+
   await server.register(
     configureEnginePlugin(formFileName, formFilePath, options)
   );
+  // clientSideUpload uses authStrategy, which is dynamically assigned,
+  // we need to register clientSideUpload afterwards, order matters.
+  // runner/src/server/plugins/engine/plugin.ts:102
   await server.register(clientSideUpload);
+
   await server.register(pluginApplicationStatus);
   await server.register(pluginRouter);
   await server.register(pluginErrorPages);

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -105,7 +105,6 @@ async function createServer(routeConfig: RouteConfig) {
   await server.register(configureCrumbPlugin(config, routeConfig));
   await server.register(Schmervice);
   await server.register(pluginAuth);
-  await server.register(clientSideUpload);
 
   server.registerService([
     CacheService,
@@ -171,6 +170,7 @@ async function createServer(routeConfig: RouteConfig) {
   await server.register(
     configureEnginePlugin(formFileName, formFilePath, options)
   );
+  await server.register(clientSideUpload);
   await server.register(pluginApplicationStatus);
   await server.register(pluginRouter);
   await server.register(pluginErrorPages);

--- a/runner/src/server/plugins/clientSideUpload.ts
+++ b/runner/src/server/plugins/clientSideUpload.ts
@@ -1,4 +1,5 @@
 import { HapiRequest, HapiResponseToolkit } from "../types";
+import { authStrategy } from "server/plugins/engine/plugin";
 
 export default {
   plugin: {
@@ -7,11 +8,17 @@ export default {
       server.route({
         method: "POST",
         path: "/s3/{id}/{pageKey}/{componentKey}/create-pre-signed-url",
-        handler: async (request: HapiRequest) => {
+        options: {
+          auth: authStrategy,
+        },
+        handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
           const { uploadService, cacheService } = request.services([]);
           const state = await cacheService.getState(request);
           const form_session_identifier =
             state.metadata?.form_session_identifier ?? "";
+          if (!form_session_identifier) {
+            return h.response({ ok: false }).code(401);
+          }
           const { id, pageKey, componentKey } = request.params as any;
           const { filename } = request.payload;
 
@@ -37,11 +44,17 @@ export default {
       server.route({
         method: "GET",
         path: "/s3/{id}/{pageKey}/{componentKey}/download-file",
+        options: {
+          auth: authStrategy,
+        },
         handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
           const { uploadService, cacheService } = request.services([]);
           const state = await cacheService.getState(request);
           const form_session_identifier =
             state.metadata?.form_session_identifier ?? "";
+          if (!form_session_identifier) {
+            return h.response({ ok: false }).code(401);
+          }
           const { id, pageKey, componentKey } = request.params as any;
           const { filename } = request.query;
 
@@ -54,11 +67,17 @@ export default {
       server.route({
         method: "DELETE",
         path: "/s3/{id}/{pageKey}/{componentKey}/delete-file-by-key",
+        options: {
+          auth: authStrategy,
+        },
         handler: async (request, h) => {
           const { uploadService, cacheService } = request.services([]);
           const state = await cacheService.getState(request);
           const form_session_identifier =
             state.metadata?.form_session_identifier ?? "";
+          if (!form_session_identifier) {
+            return h.response({ ok: false }).code(401);
+          }
           const { id, pageKey, componentKey } = request.params as any;
           const { filename } = request.payload;
 

--- a/runner/src/server/plugins/engine/components/ClientSideFileUploadField.ts
+++ b/runner/src/server/plugins/engine/components/ClientSideFileUploadField.ts
@@ -38,7 +38,10 @@ export class ClientSideFileUploadField extends FormComponent {
         // we wait an arbitrary amount of 1 second here, because of race conditions.
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
-        const files = await uploadService.listFilesInBucketFolder(key);
+        const files = await uploadService.listFilesInBucketFolder(
+          key,
+          form_session_identifier
+        );
 
         const maxFiles = this.options.dropzoneConfig.maxFiles;
         if (files.length > maxFiles) {

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -467,7 +467,10 @@ export class PageControllerBase {
             ? currentPath.split("?")[0]
             : currentPath;
           const folderPath = `${form_session_identifier}${pageAndForm}/${comp.model.id}`;
-          const files = await uploadService.listFilesInBucketFolder(folderPath);
+          const files = await uploadService.listFilesInBucketFolder(
+            folderPath,
+            form_session_identifier
+          );
           comp.model.existingFiles.push(...files);
         }
       }
@@ -926,7 +929,10 @@ export class PageControllerBase {
           ? currentPath.split("?")[0]
           : currentPath;
         const folderPath = `${form_session_identifier}${pageAndForm}/${comp.model.id}`;
-        const files = await uploadService.listFilesInBucketFolder(folderPath);
+        const files = await uploadService.listFilesInBucketFolder(
+          folderPath,
+          form_session_identifier
+        );
         comp.model.existingFiles.push(...files);
       }
     }

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -43,7 +43,8 @@ export class SummaryPageController extends PageController {
           if (comp) {
             const folderPath = `${comp.pageId}/${comp.name}`;
             const files = await uploadService.listFilesInBucketFolder(
-              `${form_session_identifier}${folderPath}`
+              `${form_session_identifier}${folderPath}`,
+              form_session_identifier
             );
             comp.value = {
               folderPath,
@@ -162,7 +163,8 @@ export class SummaryPageController extends PageController {
           if (comp) {
             const folderPath = `${comp.pageId}/${comp.name}`;
             const files = await uploadService.listFilesInBucketFolder(
-              `${form_session_identifier}${folderPath}`
+              `${form_session_identifier}${folderPath}`,
+              form_session_identifier
             );
             comp.value = {
               folderPath,

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -59,6 +59,7 @@ type PluginOptions = {
   previewMode: boolean;
 };
 
+export let authStrategy;
 export const plugin = {
   name: "@xgovformbuilder/runner/engine",
   dependencies: "@hapi/vision",
@@ -97,6 +98,12 @@ export const plugin = {
         jwtStrategyOptions(config.jwtAuthCookieName)
       );
     }
+
+    authStrategy = config.basicAuthOn
+      ? basicAuthStrategyName
+      : jwtAuthStrategyIsActive
+      ? jwtAuthStrategyName
+      : options.auth;
 
     /**
      * The following publish endpoints (/publish, /published/{id}, /published)
@@ -227,11 +234,7 @@ export const plugin = {
       method: "get",
       path: "/{id}/{path*}",
       options: {
-        auth: config.basicAuthOn
-          ? basicAuthStrategyName
-          : jwtAuthStrategyIsActive
-          ? jwtAuthStrategyName
-          : options.auth,
+        auth: authStrategy,
       },
       handler: (request: HapiRequest, h: HapiResponseToolkit) => {
         const { path, id } = request.params;
@@ -293,11 +296,7 @@ export const plugin = {
             userPathLimit: 10,
           },
         },
-        auth: config.basicAuthOn
-          ? basicAuthStrategyName
-          : jwtAuthStrategyIsActive
-          ? jwtAuthStrategyName
-          : options.auth,
+        auth: authStrategy,
         payload: {
           output: "stream",
           parse: true,

--- a/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
+++ b/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
@@ -151,7 +151,7 @@
                     <div class="dz-template govuk-table__row dz-success">
                         <div class="govuk-table__cell dz-table__cell">
                             <a class="govuk-link govuk-link--no-underline"
-                               href="/s3/report-a-terrorist/yes-i-have-evidence/koE_ae/download-file?filename={{file.Key}}">
+                               href="/s3/report-a-terrorist/yes-i-have-evidence/koE_ae/download-file?filename={{file.Key}}&form_session_identifier={{file.FormSessionId}}">
                                 {{ file.Key }}
                             </a>
                         </div>
@@ -318,7 +318,11 @@
         fetch(window.location.origin + fetchUrl, {
             method: "DELETE",
             headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({filename: file.name}),
+            credentials: "include",
+            body: JSON.stringify({
+                filename: file.name,
+                crumb: document.querySelector('form > input[name="crumb"]').value
+            }),
         })
     }
 
@@ -351,7 +355,7 @@
         updateProgressBarContent(file, 'Complete');
         const hrefContainer = file.previewElement.querySelector('a');
         const encodedFilename = encodeURIComponent(file.name);
-        hrefContainer.href = `/s3/${uniquePath}/download-file?filename=${encodedFilename}`;
+        hrefContainer.href = `/s3/${uniquePath}/download-file${window.location.search}&filename=${encodedFilename}`;
     });
 
     let preExistingFiles = [];
@@ -371,8 +375,12 @@
         let fetchUrl = `/s3/${uniquePath}/create-pre-signed-url${window.location.search}`;
         const response = await fetch(window.location.origin + fetchUrl, {
             method: 'POST',
-            body: JSON.stringify({filename: file.name}),
-            headers: {'Content-Type': 'application/json'}
+            credentials: "include",
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                filename: file.name,
+                crumb: document.querySelector('form > input[name="crumb"]').value
+            }),
         });
         return response.ok && (await response.json()).url
     }

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -366,7 +366,10 @@ export class UploadService {
     return path.replace(/^\//, "").replace(/\/$/, "");
   }
 
-  async listFilesInBucketFolder(folderPath: string): Promise<S3Object[]> {
+  async listFilesInBucketFolder(
+    folderPath: string,
+    formSessionId: string
+  ): Promise<S3Object[]> {
     const params = {
       Bucket: bucketName,
       Prefix: `${folderPath}/`,
@@ -380,6 +383,7 @@ export class UploadService {
 
     const files = response.Contents.filter((obj) => !obj.Key.endsWith("/")).map(
       (obj) => ({
+        FormSessionId: formSessionId,
         Key: obj.Key!.replace(`${folderPath}/`, ""),
         Size: obj.Size!,
       })

--- a/runner/src/server/views/partials/summary-row.html
+++ b/runner/src/server/views/partials/summary-row.html
@@ -14,7 +14,7 @@
             {% elif item.type == 'ClientSideFileUploadField' %}
                 {% for file in item.value.files %}
                     <div>
-                        <a class="govuk-link" href="/s3{{item.value.folderPath}}/download-file?filename={{file.Key}}">
+                        <a class="govuk-link" href="/s3{{item.value.folderPath}}/download-file?filename={{file.Key}}&form_session_identifier={{file.FormSessionId}}">
                             {{ file.Key }}
                         </a>
                     </div>


### PR DESCRIPTION
# Description

- Change forms to use ClientSideFileUploadField
- Add crumb on front-end for authentication on POST route
- Fix download of files by adding form session identifier

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How can I test this?

Easy way? Use the dev environment with it deployed.

- [Deployed](https://github.com/communitiesuk/digital-form-builder/actions/runs/4762766179) via https://github.com/communitiesuk/digital-form-builder/compare/fs-2421-csu-auth-forms...communitiesuk:digital-form-builder:temp-test-forms-file-upload

Locally? you can test this with the following steps:
- Grab the docker image from the workflow
- Adjust the base image tag of the form runner in the [docker compose](https://github.com/communitiesuk/funding-service-design-docker-runner/blob/28f896ce70a1bcbf9c0cd8a7a1b14c1e01ecf42a/docker-compose.yml#L108)
```diff
diff --git a/fsd_config/Dockerfile b/fsd_config/Dockerfile
--- a/fsd_config/Dockerfile
+++ b/fsd_config/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG="latest"
+ARG BASE_IMAGE_TAG="fs-2421-csu-auth-forms"
 FROM ghcr.io/communitiesuk/digital-form-builder-dluhc-runner:$BASE_IMAGE_TAG as base
 ARG FORMS_DIR="forms-v3"
 WORKDIR /usr/src/app
```
- Run the following from the root of the docker-runner repo:
```bash
docker compose build form-runner --no-cache
docker compose up form-runner
```
- Ensure other applications are running as usual
- Force open rounds on [fund-store](https://github.com/communitiesuk/funding-service-design-docker-runner/blob/28f896ce70a1bcbf9c0cd8a7a1b14c1e01ecf42a/docker-compose.yml#L7), as you will need to make an application or modify one
```diff
diff --git a/docker-compose.yml b/docker-compose.yml
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
     command: ['flask', 'run', '--host', '0.0.0.0', '--port', '8080']
     environment:
       - FLASK_ENV=development
+      - FORCE_OPEN=true
     ports: 
       - 3001:8080
     volumes: ['../funding-service-design-fund-store:/app']
```
- Load the frontend & authenticate
- Create or modify an existing application (recommend creating)
- Go to any of the modified forms, i.e business upload
- Use the file upload component on the page as intuitively as you would

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [x] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
