### PR TITLE
Fix for dateparts displaying as a Standard ISO

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.60" # Manually increment this version when pushing to main
+  VERSION: "0.1.61" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/components/MultiInputField.ts
+++ b/runner/src/server/plugins/engine/components/MultiInputField.ts
@@ -11,6 +11,7 @@ import {
 import { FormModel } from "../models";
 import { Schema } from "joi";
 import { DataType } from "./types";
+import { parseISO, format } from "date-fns";
 
 export class MultiInputField extends FormComponent {
   children: ComponentCollection;
@@ -59,7 +60,13 @@ export class MultiInputField extends FormComponent {
       for (var value of values) {
         let outputString = "";
         for (const key in value) {
-          outputString += `${this.getPrefix(key)}${value[key]} : `;
+          // TODO: Currently there are only a certain amount of fields for add another that will work. (see MultiInputField.html)
+          // lets come up with a better way of covereting each date type to a viewable string
+          if (this.getComponentType(key) == "DatePartsField") {
+            outputString += `${format(parseISO(value[key]), "d/MM/yyyy")} : `;
+          } else {
+            outputString += `${this.getPrefix(key)}${value[key]} : `;
+          }
         }
         // This will remove the : and a blank space at the end of the string. Helps with displaying on summary page.
         outputString = outputString.slice(0, -2);

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -173,7 +173,7 @@ export class RepeatingSummaryPageController extends PageController {
       const valueValues: string[] = [];
       for (const key in value) {
         if (this.inputComponent.getComponentType(key) == "DatePartsField") {
-          valueValues.push(format(parseISO(value[key]), "d MMMM yyyy"));
+          valueValues.push(format(parseISO(value[key]), "d/MM/yyyy"));
         } else {
           valueValues.push(
             `${this.inputComponent.getPrefix(key)}${value[key]}`


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Fix for how Date parts was displaying on the summary page and adding a todo
![image](https://user-images.githubusercontent.com/97108643/236419932-f32a033a-3e29-4584-88f0-73ff03c3813a.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Add a date part to the add another json children 
```
{
              "type": "DatePartsField",
              "name": "datePartsField",
              "title": "Date parts field",
              "options": {},
              "schema": {}
            }
```
- [ ] fill out the form an navigate to the summary page


# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
