### PR TITLE
Optional add another now shows Not supplied

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.89" # Manually increment this version when pushing to main
+  VERSION: "0.1.90" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/components/MultiInputField.ts
+++ b/runner/src/server/plugins/engine/components/MultiInputField.ts
@@ -63,7 +63,9 @@ export class MultiInputField extends FormComponent {
           // TODO: Currently there are only a certain amount of fields for add another that will work. (see MultiInputField.html)
           // lets come up with a better way of covereting each date type to a viewable string
           const componentTyoe = this.getComponentType(key);
-          if (componentTyoe == "DatePartsField") {
+          if (value[key] == null) {
+            outputString += "Not supplied : ";
+          } else if (componentTyoe == "DatePartsField") {
             outputString += `${format(parseISO(value[key]), "d/MM/yyyy")} : `;
           } else if (componentTyoe == "MonthYearField") {
             const monthYearValue = value[key];

--- a/runner/src/server/views/repeating-summary.html
+++ b/runner/src/server/views/repeating-summary.html
@@ -25,7 +25,7 @@
                   {% if not (value.text == "null") %}
                     <td class={{value.class}}>{{ value.text }}</td>
                   {% else %}
-                  <td class={{value.class}}>Not Supplied</td>
+                  <td class={{value.class}}>Not supplied</td>
                   {% endif %}  
                 {% endfor %}        
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Add another components with an optional field in them now show not supplied instead of null on the summary page
![image](https://github.com/communitiesuk/digital-form-builder/assets/97108643/b3463c35-b4b6-438d-9960-77e76df79b93)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Navigate to a form with a add another component with an optional field in it (funding required should be one)
- [ ] Fill out the form and check the summary

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
