### PR TITLE
FS-2917: Fix ordering of Add another components

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.102" # Manually increment this version when pushing to main
+  VERSION: "0.1.104" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"


### PR DESCRIPTION
### Description

In this image, you can see the ordering is incorrect, this happens after saving your answers and re-entering the section from the tasklist. 

![image](https://github.com/communitiesuk/digital-form-builder/assets/117724519/82a877ec-51a7-43da-b117-67c3f0f9b197)

The root cause of this is because we're relying on the order of the object literal which is serialised into the database, however upon re-rendering the order is changed as it's unreliable, the prior code assumed the first entry of the object literal was the first component, but that's not the case due to the order being messed up.

To fix this, I've changed the logic from relying on the first element of the object literal, and instead of building a list of rows, we built a new object literal with a mapping of `name`/`key` -> `value`, we can use this in combination with the ordered list of component `name(s)`/`key(s)` to ensure the rows are added in the correct order, with the first being the `header`.
