### PR TITLE
FS-2957/FS-2927: Make MultiInputField explicit when required

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.105" # Manually increment this version when pushing to main
+  VERSION: "0.1.106" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/fsd_config/form_jsons/cof_r3/cy/costau-gweithredol-cof-r3-w1.json
+++ b/fsd_config/form_jsons/cof_r3/cy/costau-gweithredol-cof-r3-w1.json
@@ -97,7 +97,8 @@
           "name": "MSNJQD",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"]
+            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Sources of income",
@@ -163,7 +164,8 @@
           "name": "NPgwcH",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Costau rhedeg", "Swm", "Gweithredu"]
+            "columnTitles": ["Costau rhedeg", "Swm", "Gweithredu"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Costau rhedeg",

--- a/fsd_config/form_jsons/cof_r3/cy/cyllid-sydd-ei-angen-cof-r3-w1.json
+++ b/fsd_config/form_jsons/cof_r3/cy/cyllid-sydd-ei-angen-cof-r3-w1.json
@@ -111,7 +111,8 @@
           "name": "qQLyXL",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Disgrifiad", "Swm", "Gweithredu "]
+            "columnTitles": ["Disgrifiad", "Swm", "Gweithredu "],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Costau cyfalaf",
@@ -200,7 +201,8 @@
           "name": "MopCmv",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"]
+            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Wedi sicrhau arian cyfatebol",
@@ -289,7 +291,8 @@
           "name": "vEOdBS",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"]
+            "columnTitles": ["Ffynhonnell", "Swm", "Gweithredu"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Arian cyfatebol heb ei sicrhau",

--- a/fsd_config/form_jsons/cof_r3/en/funding-required-cof-r3-w1.json
+++ b/fsd_config/form_jsons/cof_r3/en/funding-required-cof-r3-w1.json
@@ -109,7 +109,8 @@
           "name": "qQLyXL",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Description", "Amount", "Action"]
+            "columnTitles": ["Description", "Amount", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Capital costs",
@@ -198,7 +199,8 @@
           "name": "MopCmv",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Source", "Amount", "Action"]
+            "columnTitles": ["Source", "Amount", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Secured match funding",
@@ -287,7 +289,8 @@
           "name": "vEOdBS",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Source", "Amount", "Action"]
+            "columnTitles": ["Source", "Amount", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Unsecured match funding",

--- a/fsd_config/form_jsons/cof_r3/en/operational-costs-cof-r3-w1.json
+++ b/fsd_config/form_jsons/cof_r3/en/operational-costs-cof-r3-w1.json
@@ -95,7 +95,8 @@
           "name": "MSNJQD",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Source", "Amount", "Action"]
+            "columnTitles": ["Source", "Amount", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Sources of income",
@@ -161,7 +162,8 @@
           "name": "NPgwcH",
           "options": {
             "prefix": "£",
-            "columnTitles": ["Running cost", "Amount", "Action"]
+            "columnTitles": ["Running cost", "Amount", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Running costs",

--- a/fsd_config/form_jsons/night_shelter/building-works-ns.json
+++ b/fsd_config/form_jsons/night_shelter/building-works-ns.json
@@ -260,7 +260,8 @@
         {
           "name": "SQEpBt",
           "options": {
-            "columnTitles": ["Job role", "Organisation name", "Action"]
+            "columnTitles": ["Job role", "Organisation name", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Details of professional advisors",
@@ -367,7 +368,8 @@
         {
           "name": "UDhjLS",
           "options": {
-            "columnTitles": ["Contractor", "Action"]
+            "columnTitles": ["Contractor", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Your contractors",

--- a/fsd_config/form_jsons/night_shelter/joint-applications-ns.json
+++ b/fsd_config/form_jsons/night_shelter/joint-applications-ns.json
@@ -67,7 +67,8 @@
               "Organisation",
               "How you'll work together",
               "Action"
-            ]
+            ],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Your partner organisations",

--- a/fsd_config/form_jsons/night_shelter/match-funding-ns.json
+++ b/fsd_config/form_jsons/night_shelter/match-funding-ns.json
@@ -83,7 +83,8 @@
               "Capital or revenue",
               "Secured",
               "Action"
-            ]
+            ],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Match funding",

--- a/fsd_config/form_jsons/night_shelter/objectives-and-activities-ns.json
+++ b/fsd_config/form_jsons/night_shelter/objectives-and-activities-ns.json
@@ -73,7 +73,8 @@
         {
           "name": "kRxOHF",
           "options": {
-            "columnTitles": ["Objective", "Activities", "Action"]
+            "columnTitles": ["Objective", "Activities", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Proposal milestones",

--- a/fsd_config/form_jsons/night_shelter/organisation-type-ns.json
+++ b/fsd_config/form_jsons/night_shelter/organisation-type-ns.json
@@ -148,7 +148,8 @@
         {
           "name": "ILVEOG",
           "options": {
-            "columnTitles": ["Full name", "Action"]
+            "columnTitles": ["Full name", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Your trustees or committee members",

--- a/fsd_config/form_jsons/night_shelter/project-milestones-ns.json
+++ b/fsd_config/form_jsons/night_shelter/project-milestones-ns.json
@@ -44,7 +44,8 @@
         {
           "name": "sXlkAm",
           "options": {
-            "columnTitles": ["Milestone", "Date", "Action"]
+            "columnTitles": ["Milestone", "Date", "Action"],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Milestones",

--- a/fsd_config/form_jsons/night_shelter/risk-and-deliverability-ns.json
+++ b/fsd_config/form_jsons/night_shelter/risk-and-deliverability-ns.json
@@ -49,7 +49,8 @@
               "Likelihood",
               "Proposed mitigation",
               "Action"
-            ]
+            ],
+            "required": true
           },
           "type": "MultiInputField",
           "title": "Risk",


### PR DESCRIPTION
Following on from https://github.com/communitiesuk/digital-form-builder/pull/230 - we make `MultiInputField`s explicitly required instead of implicitly, this should change the schema to re-validate upon re-routing prompting the user to fill in the section.  

Testing instructions:
- Pull the docker image from the github build (or build the forms locally, since only a form change)
- Launch the apps, and go to night shelter r2: http://localhost:3008/funding-round/nstf/r2
- Login, create an application
- Go to 1.2 Organisation type
- Select `Charity` & full out forms to summary page
- Select `Change` on "How is your organisation classified?"
- Change to "None of these"
- It should prompt you for 
    - "How is your organisation classified?"
    - Your trustees or committee members

Note, the file upload sections aren't prompted.  This will be addressed by another PR, ticket.