### PR TITLE
FS-2897: Use filter instead of find

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.105" # Manually increment this version when pushing to main
+  VERSION: "0.1.107" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -37,10 +37,10 @@ export class SummaryPageController extends PageController {
         state.metadata?.form_session_identifier ?? "";
       if (form_session_identifier) {
         for (const detail of viewModel.details) {
-          const comp = detail.items.find(
+          const comps = detail.items.filter(
             (c) => c.type === "ClientSideFileUploadField"
           );
-          if (comp) {
+          for (const comp of comps) {
             const folderPath = `${comp.pageId}/${comp.name}`;
             const files = await uploadService.listFilesInBucketFolder(
               `${form_session_identifier}${folderPath}`,
@@ -157,10 +157,10 @@ export class SummaryPageController extends PageController {
         state.metadata?.form_session_identifier ?? "";
       if (form_session_identifier) {
         for (const detail of summaryViewModel.details) {
-          const comp = detail.items.find(
+          const comps = detail.items.filter(
             (c) => c.type === "ClientSideFileUploadField"
           );
-          if (comp) {
+          for (const comp of comps) {
             const folderPath = `${comp.pageId}/${comp.name}`;
             const files = await uploadService.listFilesInBucketFolder(
               `${form_session_identifier}${folderPath}`,


### PR DESCRIPTION
### Description

Previously, we were just using `.find` on the summary page, this was only bringing back the first client side file upload component.  In this PR, we change from `.find` to `.filter`, so we get all instead of just the first, we also iterate over them.

### How to test

- Pull the image from this PR 
- Add the image to your docker locally
- Add a form that has multiple client side file upload components
- Add AWS service-key credentials to your nodemon/form-runner
- `docker compose up form-runner --build`
- Navigate to the form you added
- Complete the form, uploading file at various points
- Observe the summary page now rendering multiple file names

### Screenshot

![image](https://github.com/communitiesuk/digital-form-builder/assets/117724519/c90a7fa7-ceab-4e02-8cb7-cd63175406f0)
