### PR TITLE
FS-2972: Sort errors by order

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.113" # Manually increment this version when pushing to main
+  VERSION: "0.1.114" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -58,7 +58,31 @@ export class SummaryPageController extends PageController {
             message: text,
           };
         });
-        viewModel.errors = [...(viewModel.errors || []), ...restructuredErrors];
+        const allErrorsUnsorted = [
+          ...(viewModel.errors || []),
+          ...restructuredErrors,
+        ];
+
+        const sortedPathNames = model.pages
+          .filter(
+            (page) => page.section?.name && page.components.items.length > 0
+          )
+          .map((page) => [
+            page.section?.name,
+            page.components.items.map((item) => item.name),
+          ])
+          .flatMap(([prefix, suffixes]) =>
+            suffixes.map((suffix) => `${prefix}.${suffix}`)
+          );
+
+        const sortedErrors = [...allErrorsUnsorted].sort((a, b) => {
+          const indexA = sortedPathNames.indexOf(a.path);
+          const indexB = sortedPathNames.indexOf(b.path);
+
+          return indexA - indexB;
+        });
+
+        viewModel.errors = sortedErrors;
       }
 
       viewModel.footer = this.def.footer;
@@ -211,10 +235,31 @@ export class SummaryPageController extends PageController {
             message: text,
           };
         });
-        summaryViewModel.errors = [
+        const allErrorsUnsorted = [
           ...(summaryViewModel.errors || []),
           ...restructuredErrors,
         ];
+
+        const sortedPathNames = model.pages
+          .filter(
+            (page) => page.section?.name && page.components.items.length > 0
+          )
+          .map((page) => [
+            page.section?.name,
+            page.components.items.map((item) => item.name),
+          ])
+          .flatMap(([prefix, suffixes]) =>
+            suffixes.map((suffix) => `${prefix}.${suffix}`)
+          );
+
+        const sortedErrors = [...allErrorsUnsorted].sort((a, b) => {
+          const indexA = sortedPathNames.indexOf(a.path);
+          const indexB = sortedPathNames.indexOf(b.path);
+
+          return indexA - indexB;
+        });
+
+        summaryViewModel.errors = sortedErrors;
       }
 
       const form_session_identifier =


### PR DESCRIPTION
### Description

The return to summary page acts as a queue, so we need to sort all the errors by their correct order.  Previously all file uploads would show at the end as the validation is separated and was just concatenated, now they show in the right order.