### PR TITLE
FS-2918: Return string if already string

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.122" # Manually increment this version when pushing to main
+  VERSION: "0.1.123" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -14,6 +14,7 @@ function answerFromDetailItem(item) {
       return date;
     case "monthYear":
       if (typeof item.rawValue === "undefined") return "undefined";
+      if (typeof item.rawValue === "string") return item.rawValue;
       const [month, year] = Object.values(item.rawValue);
       return format(new Date(`${year}-${month}-1`), "yyyy-MM");
     case "multiInput":


### PR DESCRIPTION
### Description

`MonthYear` component is saved as a string, i.e `2003-02` - however this bit of a code made the assumption it was always an object, due to this, the date would get malformed, i.e:

```javascript
const [month, year] = Object.values("2003-02");
const dateString = `${year}-${month}-1`
console.log(dateString) // 0-2-1
console.log(new Date(dateString)) // Tue Feb 01 2000 00:00:00 GMT+0000 (Greenwich Mean Time)
```

This was causing all kinds of weird looking behaviour, as the dates were randomly shuffling themselves around due to the assumption that it was always an object, for a fix, I've put in to check that if it's a string, and if is, then the date is already formatted, so we can just return, we don't need to go through the transformation logic to turn it into a string.