### PR TITLE
Fs 3348 remove feedback link

### DIFF
--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -9,7 +9,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+    html: 'This is a new service.'
   }) }}
 {% endblock %}
 

--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -9,7 +9,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service.'
+    html: "This is a new service."
   }) }}
 {% endblock %}
 

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -115,7 +115,7 @@
                 tag: {
                     text: phaseTag
                 },
-                html: 'This is a new service.'
+                html: "This is a new service."
             }) }}
         {% else %}
             {{ govukPhaseBanner({

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -115,7 +115,7 @@
                 tag: {
                     text: phaseTag
                 },
-                html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+                html: 'This is a new service.'
             }) }}
         {% else %}
             {{ govukPhaseBanner({

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -7,7 +7,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service.'
+    html: "This is a new service."
   }) }}
 {% endblock %}
 {% block content %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -7,7 +7,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+    html: 'This is a new service.'
   }) }}
 {% endblock %}
 {% block content %}

--- a/runner/test/cases/server/feedback.test.js
+++ b/runner/test/cases/server/feedback.test.js
@@ -31,8 +31,7 @@ suite(`Feedback`, () => {
     expect(response.headers["content-type"]).to.include("text/html");
 
     const $ = cheerio.load(response.payload);
-
-    expect($(".govuk-phase-banner__text").attr("text")).to.equal(
+    expect($(".govuk-phase-banner__text").text().trim()).to.equal(
       "This is a new service."
     );
   });

--- a/runner/test/cases/server/feedback.test.js
+++ b/runner/test/cases/server/feedback.test.js
@@ -32,8 +32,8 @@ suite(`Feedback`, () => {
 
     const $ = cheerio.load(response.payload);
 
-    expect($(".govuk-phase-banner__text .govuk-link").attr("href")).to.equal(
-      "mailto:test@feedback.cat"
+    expect($(".govuk-phase-banner__text").attr("text")).to.equal(
+      "This is a new service."
     );
   });
 });


### PR DESCRIPTION
### Change description
FS-3348 removing feedback link from text in beta banner


### How to test
Navigate to the frontend and view the beta banner


### Screenshots of UI changes (if applicable)
![Screenshot 2023-08-23 at 14 45 01](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/5f6d88f6-a43d-4b09-aca3-7e51afa0e08f)
