### PR TITLE
Fix for wrong ordering on question change

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -63,7 +63,7 @@ export class SummaryPageController extends PageController {
           ...restructuredErrors,
         ];
 
-        const sortedPathNames = model.pages
+        const sortedPathNames = relevantPages
           .filter(
             (page) => page.section?.name && page.components.items.length > 0
           )


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- When a question was changed, all the client side uploads questions would be put to the end. The questions should now appear in the correct order.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] On the Asset information form on window 2, if you complete the form then change the answer of How do you intend to take community ownership of the asset? The questions after this should appear in the correct order

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
