### PR TITLE
FS-3441 added yelp hook for secrets

### DIFF
--- a/.github/workflows/dluhc-build-and-deploy-with-forms.yml
+++ b/.github/workflows/dluhc-build-and-deploy-with-forms.yml
@@ -111,10 +111,10 @@ jobs:
       perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
       perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
       perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
-      e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
-      e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
-      e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
-      e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
+      e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev  # pragma: allowlist secret
+      e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
+      e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev  # pragma: allowlist secret
+      e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev  # pragma: allowlist secret
       run_performance_tests: true
       run_e2e_tests: false
     secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-ast
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--disable-plugin', 'HexHighEntropyString',
+          '--disable-plugin', 'Base64HighEntropyString']
+        exclude: runner/config/custom-environment-variables.json

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -44,7 +44,7 @@ describe("OutputEdit", () => {
           type: "notify",
           outputConfiguration: {
             templateId: "123ID",
-            apiKey: "123KEY",  // pragma: allowlist secret
+            apiKey: "123KEY", // pragma: allowlist secret
             emailField: "9WH4EX",
             personalisation: [],
           },

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -44,7 +44,7 @@ describe("OutputEdit", () => {
           type: "notify",
           outputConfiguration: {
             templateId: "123ID",
-            apiKey: "123KEY",
+            apiKey: "123KEY",  // pragma: allowlist secret
             emailField: "9WH4EX",
             personalisation: [],
           },

--- a/designer/server/__tests__/config.jest.ts
+++ b/designer/server/__tests__/config.jest.ts
@@ -64,7 +64,7 @@ describe("Config", () => {
       ...OLD_ENV,
       PERSISTENT_BACKEND: "s3",
       AWS_ACCESS_KEY_ID: "key",
-      AWS_SECRET_ACCESS_KEY: "secret",  // pragma: allowlist secret
+      AWS_SECRET_ACCESS_KEY: "secret", // pragma: allowlist secret
     };
     jest.resetModules();
     await expect(import("../config")).resolves.toBeTruthy();

--- a/designer/server/__tests__/config.jest.ts
+++ b/designer/server/__tests__/config.jest.ts
@@ -64,7 +64,7 @@ describe("Config", () => {
       ...OLD_ENV,
       PERSISTENT_BACKEND: "s3",
       AWS_ACCESS_KEY_ID: "key",
-      AWS_SECRET_ACCESS_KEY: "secret",
+      AWS_SECRET_ACCESS_KEY: "secret",  // pragma: allowlist secret
     };
     jest.resetModules();
     await expect(import("../config")).resolves.toBeTruthy();

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
     "magic-string": "^0.25.7",
+    "pre-commit": "^1.2.2",
     "prettier": "2.1.2",
     "typedoc": "^0.20.36",
     "typescript": "^4.1.3"


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugins `HexHighEntropyString` & `Base64HighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API key/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 