### PR TITLE
Fix for Uk address field being optional

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -13,7 +13,7 @@ on:
       ]
 
 env:
-  VERSION: "0.1.149" # Manually increment this version when pushing to main
+  VERSION: "0.1.150" # Manually increment this version when pushing to main
   IMAGE_NAME_STUB: "digital-form-builder-dluhc-"
   DOCKER_REGISTRY: ghcr.io
   IMAGE_REPO_PATH: "ghcr.io/${{github.repository_owner}}"

--- a/fsd_config/form_jsons/cyp_r1/about-your-organisation-cyp.json
+++ b/fsd_config/form_jsons/cyp_r1/about-your-organisation-cyp.json
@@ -269,7 +269,8 @@
         {
           "name": "smBPvK",
           "options": {
-            "hideTitle": true
+            "hideTitle": true,
+            "required": false
           },
           "type": "UkAddressField",
           "title": "Alternative organisation address",

--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -45,7 +45,11 @@ export class UkAddressField extends FormComponent {
         name: "addressLine1",
         title: addressLine1Title,
         schema: { max: 100 },
-        options: { required: isRequired, classes: "govuk-!-width-full" },
+        options: {
+          required: isRequired,
+          classes: "govuk-!-width-full",
+          optionalText: false,
+        },
       },
       {
         type: "TextField",
@@ -59,7 +63,11 @@ export class UkAddressField extends FormComponent {
         name: "town",
         title: townCityText,
         schema: { max: 100 },
-        options: { required: isRequired, classes: "govuk-!-width-two-thirds" },
+        options: {
+          required: isRequired,
+          classes: "govuk-!-width-two-thirds",
+          optionalText: false,
+        },
       },
       {
         type: "TextField",
@@ -81,6 +89,7 @@ export class UkAddressField extends FormComponent {
           required: isRequired,
           customValidationMessage: "Enter a valid postcode",
           classes: "govuk-!-width-one-half",
+          optionalText: false,
         },
       },
     ];
@@ -153,7 +162,11 @@ export class UkAddressField extends FormComponent {
     const name = this.name;
     const value = state[name];
 
-    if (typeof value !== "string" && typeof value !== "undefined") {
+    if (
+      typeof value !== "string" &&
+      typeof value !== "undefined" &&
+      value !== null
+    ) {
       value.addressLine2 =
         value.addressLine2 === "" ? "null" : value.addressLine2;
       value.county = value.county === "" ? "null" : value.county;


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.
https://dluhcdigital.atlassian.net/browse/FS-3515

- Fix to a issue with UkAddress field being optional and fixed routing for the about your organisation form
![image](https://github.com/communitiesuk/digital-form-builder/assets/97108643/a3f384fd-3153-4f17-ac76-9f2ec0a9bf7b)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] complete the about your organisation form
# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
