### PR TITLE
FS-3542 python based pre-commit hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.js text eol=lf
+*.jsx text eol=lf
+*.tsx text eol=lf
+*.ts text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tsconfig.tsbuildinfo
 .yarn/build-state.yml
 .yarn/install-state.gz
 docs/**/typedoc
+.venv

--- a/README_DLUHC.md
+++ b/README_DLUHC.md
@@ -67,3 +67,23 @@ This image is built, pushed and deployed by [Build and Deploy Forms](./.github/w
 ## .github/workflows/branch--lint-unit-and-smoke-test.yml
 
 Runs against a branch that has an open pull request against it. It will execute on every push to such a branch to build and run smoke tests. Unchanged from upstream repo.
+
+## Extras
+
+This repo comes with a .pre-commit-config.yaml, if you wish to use this do
+the following while in your virtual enviroment:
+
+    # set up virtual enviroment
+    python -m venv .venv
+    source .venv/Scripts/activate
+
+    # Install pre-commit
+    pip install pre-commit
+    pre-commit install
+
+Once the above is done you will have autoformatting (trailing-whitespace, end-of-file-fixer and check-ast) built
+into your workflow. You will be notified of any errors during commits.
+
+### `detect-secrets` hook
+We use this pre-commit hook to prevent new secrets from entering the code base.(For more info: https://github.com/Yelp/detect-secrets)
+- If the hook detects false positives, mark with an inline `pragma: allowlist secret` comment to ignore it.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
     "magic-string": "^0.25.7",
-    "pre-commit": "^1.2.2",
     "prettier": "2.1.2",
     "typedoc": "^0.20.36",
     "typescript": "^4.1.3"


### PR DESCRIPTION
# Description
https://dluhcdigital.atlassian.net/browse/FS-3542
Changing node-based pre-commit to python-based pre-commit hook

# How to Test

## Remove existing node-based pre-commit hook
If a node-based pre-commit hook already exists then remove it
```
rm .git/hooks/pre-commit
```
reinstall dependencies
```
yarn && yarn build
```
## Set up python based pre-commit hook
```
# set up virtual environment
python -m venv .venv
source .venv/Scripts/activate

# Install pre-commit
pip install pre-commit
pre-commit install
```
Now make a commit and observe python based pre-commit should kick in
