### PR TITLE
stop tag exists check if not on main (as we only tag on main)

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -85,7 +85,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: [copilot_environments_workflow_setup]
+    needs: [copilot_environments_workflow_setup, docker-build]
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:

--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   check-tag-before-build:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Stopped checking for tags existing if building from a branch, as we only tag on mian
Also updated workflow so deploy happens after build