### PR TITLE
Moving if on main check to step so it doesn't break dependsOn

### DIFF
--- a/.github/workflows/dluhc-build-and-publish.yml
+++ b/.github/workflows/dluhc-build-and-publish.yml
@@ -24,7 +24,6 @@ env:
 jobs:
   check-tag-before-build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
 
@@ -43,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fail job if tag exists
-        if: ${{ steps.check_tag.outputs.exists == 'true' }}
+        if: ${{ steps.check_tag.outputs.exists == 'true' && github.ref == 'refs/heads/main'}}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
Moved the check for if we are on main to the step that fails the workflow if the tag exists, as otherwise it breaks the depends/needs chain if we aren't on main