### PR TITLE
fs-3800 updated copilot config to set basic auth to false

### DIFF
--- a/copilot/fsd-form-runner/manifest.yml
+++ b/copilot/fsd-form-runner/manifest.yml
@@ -54,7 +54,7 @@ variables:
   ACCESSIBILITY_STATEMENT_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/accessibility_statement"
   AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
-  BASIC_AUTH_ON: true
+  BASIC_AUTH_ON: false
   CONTACT_US_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/contact_us"
   COOKIE_POLICY_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/cookie_policy"
   FEEDBACK_LINK: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/feedback"


### PR DESCRIPTION
Setting the `BASIC_AUTH_ON` env var to `false` as we aren't using basic auth in the aws envs