### PR TITLE
FS-4081: Make max 2 million, add pound sign

### DIFF
--- a/fsd_config/form_jsons/cof/eoi/cof-eoi-funding.json
+++ b/fsd_config/form_jsons/cof/eoi/cof-eoi-funding.json
@@ -80,9 +80,9 @@
           },
           "type": "NumberField",
           "title": "How much capital funding are you requesting from COF?",
-          "hint": "Capital costs are the costs of buying or leasing your asset and paying for refurbishment. You can apply for up to £2 million in capital costs from COF. ",
+          "hint": "<p>Capital costs are the costs of buying or leasing your asset and paying for refurbishment. You can apply for up to £2 million (<span class='govuk-!-font-size-19'>£2000000</span>) in capital costs from COF.</p><p>Enter the amount using only numerals, for example, 1500000</p>",
           "schema": {
-            "max": 2000000000
+            "max": 2000000
           }
         }
       ],

--- a/fsd_config/form_jsons/cof/eoi/cof-eoi-funding.json
+++ b/fsd_config/form_jsons/cof/eoi/cof-eoi-funding.json
@@ -75,12 +75,15 @@
         {
           "name": "fZAMFv",
           "options": {
+            "prefix": "£",
             "hideTitle": true
           },
           "type": "NumberField",
           "title": "How much capital funding are you requesting from COF?",
           "hint": "Capital costs are the costs of buying or leasing your asset and paying for refurbishment. You can apply for up to £2 million in capital costs from COF. ",
-          "schema": {}
+          "schema": {
+            "max": 2000000000
+          }
         }
       ],
       "next": [


### PR DESCRIPTION
- Change the configuration for "How much capital funding are you requesting from COF?" 
- Now has a maximum of 2 million (2000000) & a prefix of a pound sign, since it's GBP
- Also updated the hint to match the specified image/mural

![image](https://github.com/communitiesuk/digital-form-builder/assets/117724519/657ee1a4-8954-4013-a72d-a4cd193cac4a)
