### PR TITLE
BAU - increment scan number to reduce redundant cached layers

### DIFF
--- a/.github/workflows/anchore-scan.yml
+++ b/.github/workflows/anchore-scan.yml
@@ -31,9 +31,9 @@ jobs:
           # see https://github.com/satackey/action-docker-layer-caching/issues/55
           # ATM solution is to change keys periodically to avoid the dangling layers
           # for that just increase the number you see in key and restore-keys below (same number in both keys).
-          key: digital-form-builder-1-{hash}
+          key: digital-form-builder-2-{hash}
           restore-keys: |
-            digital-form-builder-1
+            digital-form-builder-2
       - name: Docker compose build
         run: |
           LAST_TAG='${{ github.run_number }}-rc'
@@ -70,9 +70,9 @@ jobs:
           # see https://github.com/satackey/action-docker-layer-caching/issues/55
           # ATM solution is to change keys periodically to avoid the dangling layers
           # for that just increase the number you see in key and restore-keys below (same number in both keys).
-          key: digital-form-builder-1-{hash}
+          key: digital-form-builder-2-{hash}
           restore-keys: |
-            digital-form-builder-1
+            digital-form-builder-2
       - name: Docker compose build
         run: |
           LAST_TAG='${{ github.run_number }}-rc'


### PR DESCRIPTION
# Description

Update key cache number as per documentation link in workflow to avoid running out of disk space during scan.
