### PR TITLE
FS-4055: Crown logo update form runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^3.15.0",
     "immutable": "^4.3.0"
   },
   "resolutions": {


### PR DESCRIPTION
### Change description

- govuk-fronend version updated to 3.15.0 from 3.13.0 which includes updated crown assets

### Ticket
https://dluhcdigital.atlassian.net/browse/FS-4055

### How to test
- By going to the forms section on the frontend service

### Screenshots of UI changes (if applicable)
<img width="1099" alt="Screenshot 2024-04-17 at 16 41 41" src="https://github.com/communitiesuk/digital-form-builder/assets/66220499/bf0a0eb4-20d1-4e85-b0c1-25fa9c25ee65">