### PR TITLE
FS-4360:declaration fix after save

### DIFF
--- a/fsd_config/form_jsons/hsra/declaration-hsra.json
+++ b/fsd_config/form_jsons/hsra/declaration-hsra.json
@@ -38,7 +38,7 @@
       "items": [
         {
           "text": "By submitting this application, you confirm that the information you have provided is correct.",
-          "value": "By submitting this application, you confirm that the information you have provided is correct."
+          "value": "confirm"
         }
       ]
     }


### PR DESCRIPTION
## Description

When declaration form section is completed and saved then after coming back from a partial form completion checkbox selection is not available

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Login to HRSA : funding-round/hsra/r1
Start a new application
Click on “Declaration” form
Click the checkbox in the form
Submit the form
From the tasklist page return to the “Declaration” form and observe the page

Expected behaviour
Checkbox should be ticked on Save and Return

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
