### PR TITLE
FS-4351: application duplicate title fix and typo

### DIFF
--- a/fsd_config/form_jsons/hsra/name-your-application-hsra.json
+++ b/fsd_config/form_jsons/hsra/name-your-application-hsra.json
@@ -3,7 +3,7 @@
   "startPage": "/what-would-you-like-to-name-you-application",
   "pages": [
     {
-      "title": "What would you like to name you application?",
+      "title": "What would you like to name your application?",
       "path": "/what-would-you-like-to-name-you-application",
       "components": [
         {
@@ -13,7 +13,7 @@
             "hideTitle": true
           },
           "type": "TextField",
-          "title": "What would you like to name you application?",
+          "title": "What would you like to name your application?",
           "hint": "Choose a unique and descriptive name. For example, the first line of the property’s address.\n<br>\n<br>\nThis will help you find your application if you save and return. We’ll also use this when we contact you about this application."
         }
       ],

--- a/fsd_config/form_jsons/hsra/name-your-application-hsra.json
+++ b/fsd_config/form_jsons/hsra/name-your-application-hsra.json
@@ -9,7 +9,8 @@
         {
           "name": "qbBtUh",
           "options": {
-            "classes": "govuk-!-width-full"
+            "classes": "govuk-!-width-full",
+            "hideTitle": true
           },
           "type": "TextField",
           "title": "What would you like to name you application?",

--- a/fsd_config/form_jsons/hsra/name-your-application-hsra.json
+++ b/fsd_config/form_jsons/hsra/name-your-application-hsra.json
@@ -1,10 +1,10 @@
 {
   "metadata": {},
-  "startPage": "/what-would-you-like-to-name-you-application",
+  "startPage": "/what-would-you-like-to-name-your-application",
   "pages": [
     {
       "title": "What would you like to name your application?",
-      "path": "/what-would-you-like-to-name-you-application",
+      "path": "/what-would-you-like-to-name-your-application",
       "components": [
         {
           "name": "qbBtUh",


### PR DESCRIPTION
# Description

Duplicate heading “What would you like to name you application and “r” is missing in “your”

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
