### PR TITLE
FS-4336: Fix form name for the HSRA question pages 

### DIFF
--- a/fsd_config/form_jsons/hsra_r1/hsra-r1-eligibility.json
+++ b/fsd_config/form_jsons/hsra_r1/hsra-r1-eligibility.json
@@ -690,5 +690,6 @@
   "outputs": [],
   "version": 2,
   "skipSummary": false,
-  "markAsComplete": false
+  "markAsComplete": false,
+  "name": "Apply for funding to cover the cost of delivering a high street rental auction"
 }

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -559,7 +559,7 @@ export class PageControllerBase {
 
       viewModel.backLink =
         state.callback?.returnUrl ?? progress[progress.length - 2];
-      if (state["metadata"]["has_eligibility"]) {
+      if (state["metadata"] && state["metadata"]["has_eligibility"]) {
         viewModel.backLinkText = UtilHelper.getBackLinkText(
           true,
           this.model.def?.metadata?.isWelsh

--- a/runner/test/cases/server/plugins/engine/NotifyViewModel.json
+++ b/runner/test/cases/server/plugins/engine/NotifyViewModel.json
@@ -1,5 +1,5 @@
 {
-  "metadata": {},
+  "metadata": { "has_eligibility": false },
   "startPage": "/first-page",
   "pages": [
     {
@@ -104,8 +104,7 @@
       "value": "aSection.caz==2"
     }
   ],
-  "fees": [
-  ],
+  "fees": [],
   "outputs": [
     {
       "name": "notify",
@@ -118,10 +117,7 @@
         "templateId": "some-template-id",
         "emailField": "aSection.emailAddress",
         "addReferencesToPersonalisation": true,
-        "personalisation": [
-          "aSection.name",
-          "nameIsJen"
-        ],
+        "personalisation": ["aSection.name", "nameIsJen"],
         "emailReplyToIdConfiguration": [
           {
             "emailReplyToId": "default-email-id"
@@ -135,6 +131,6 @@
     }
   ],
   "version": 2,
-  "payApiKey": {"test": "test_api_key", "production": "production_api_key"},
+  "payApiKey": { "test": "test_api_key", "production": "production_api_key" },
   "skipSummary": false
 }

--- a/runner/test/cases/server/plugins/engine/SaveViewModel.json
+++ b/runner/test/cases/server/plugins/engine/SaveViewModel.json
@@ -1,5 +1,5 @@
 {
-  "metadata": {},
+  "metadata": { "has_eligibility": false },
   "startPage": "/first-page",
   "pages": [
     {

--- a/runner/test/cases/server/plugins/engine/SummaryViewModel.json
+++ b/runner/test/cases/server/plugins/engine/SummaryViewModel.json
@@ -1,5 +1,5 @@
 {
-  "metadata": {},
+  "metadata": { "has_eligibility": false },
   "startPage": "/first-page",
   "pages": [
     {
@@ -103,10 +103,8 @@
       "title": "Named Section"
     }
   ],
-  "conditions": [
-  ],
-  "fees": [
-  ],
+  "conditions": [],
+  "fees": [],
   "outputs": [
     {
       "name": "webhook",
@@ -118,6 +116,6 @@
     }
   ],
   "version": 2,
-  "payApiKey": {"test": "test_api_key", "production": "production_api_key"},
+  "payApiKey": { "test": "test_api_key", "production": "production_api_key" },
   "skipSummary": false
 }

--- a/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
+++ b/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
@@ -143,7 +143,7 @@ suite("WebhookModel", () => {
       formModel
     );
     expect(parsed).to.equal({
-      metadata: {},
+      metadata: { has_eligibility: false },
       name: "My Service",
       questions: [
         {

--- a/runner/test/cases/server/plugins/engine/WelshSummaryViewModel.json
+++ b/runner/test/cases/server/plugins/engine/WelshSummaryViewModel.json
@@ -1,5 +1,5 @@
 {
-  "metadata": { "isWelsh": true },
+  "metadata": { "isWelsh": true, "has_eligibility": false },
   "startPage": "/first-page",
   "pages": [
     {

--- a/runner/test/cases/server/services/webhookService.test.ts
+++ b/runner/test/cases/server/services/webhookService.test.ts
@@ -30,7 +30,7 @@ suite("Server WebhookService Service", () => {
     const serverMock = { logger: loggerSpy };
     const webHookeService = new WebhookService(serverMock);
     const result = await webHookeService.postRequest("/url", {});
-    expect(result).to.equal("1234");
+    expect(result).to.equal({ reference: "1234" });
   });
 
   test("Webhook returns correct reference when payload is object", async () => {


### PR DESCRIPTION
FS-4336: Fix form name for the HSRA question pages 


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] My changes do not introduce any new linting errors
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
<img width="890" alt="Screenshot 2024-06-10 at 09 09 56" src="https://github.com/communitiesuk/digital-form-builder/assets/18649264/f15f659c-5d2c-4b94-9090-68003a3f2c61">
![Uploading Screenshot 2024-06-10 at 13.23.49.png…]()

