### PR TITLE
FS-3664 Read-only summary flag on the summary page

### DIFF
--- a/runner/src/server/plugins/engine/models/viewModel.ts
+++ b/runner/src/server/plugins/engine/models/viewModel.ts
@@ -55,6 +55,7 @@ export class ViewModel {
   saveAndContinueText: string;
   confirmAndContinueText?: string;
   isConfirmPageControllerRequest?: boolean;
+  isReadOnlySummary?: boolean;
   continueText: string;
   footer?: any;
 

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -201,6 +201,16 @@ export class SummaryPageController extends PageController {
         );
         viewModel.backLink = state.callback?.returnUrl;
       }
+      if (state["metadata"] && state["metadata"]["is_read_only_summary"]) {
+        viewModel.isReadOnlySummary =
+          state["metadata"]["is_read_only_summary"];
+        viewModel.backLinkText = UtilHelper.getBackLinkText(
+          true,
+          this.model.def?.metadata?.isWelsh
+        );
+        viewModel.backLink = state.callback?.returnUrl;
+      }
+
       return h.view("summary", viewModel);
     };
   }

--- a/runner/src/server/views/partials/summary-detail.html
+++ b/runner/src/server/views/partials/summary-detail.html
@@ -1,8 +1,8 @@
 {% from "./summary-row.html" import summaryRow %}
 
-{% macro summaryDetail(data) %}
+{% macro summaryDetail(data, isReadOnlySummary=false) %}
     {%  set isRepeatableSection = (data.items[0] | isArray) %}
-    {% if not isRepeatableSection %}
+    {% if (not isRepeatableSection and not isReadOnlySummary) %}
         <h2 class="govuk-heading-m">{{data.title}}</h2>
     {% endif %}
   <dl class="govuk-summary-list">
@@ -14,7 +14,7 @@
                 {{ summaryRow(repeated) }}
             {% endfor %}
         {% else %}
-          {{ summaryRow(item, data.notSuppliedText, data.changeText) }}
+          {{ summaryRow(item, data.notSuppliedText, data.changeText, isReadOnlySummary) }}
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/runner/src/server/views/partials/summary-row.html
+++ b/runner/src/server/views/partials/summary-row.html
@@ -1,4 +1,4 @@
-{% macro summaryRow(item, notSuppliedText, changeText) %}
+{% macro summaryRow(item, notSuppliedText, changeText, isReadOnlySummary) %}
 <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
         {{item.label}}
@@ -47,9 +47,11 @@
         {% endif %}
     </dd>
     <dd class="govuk-summary-list__actions">
+        {% if not isReadOnlySummary %}
         <a class="govuk-link" href="{{item.url}}">
             {{changeText}}<span class="govuk-visually-hidden"> {{item.label}}</span>
         </a>
+        {% endif %}
     </dd>
 </div>
 {% endmacro %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -3,6 +3,8 @@
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 {% extends 'layout.html' %}
 
+{% set pageTitle = pageTitle if not isReadOnlySummary else "View your answers" %}
+
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
@@ -10,10 +12,10 @@
     },
     html: "This is a new service."
   }) }}
-    {% if isConfirmPageControllerRequest %}
+    {% if isConfirmPageControllerRequest or isReadOnlySummary %}
         {{ govukBackLink({
                 href: backLink,
-                text: backLinkText
+                text: backLinkText if not isReadOnlySummary else "Back to application for funding overview"
             }) }}
     {% endif %}
 {% endblock %}
@@ -23,6 +25,11 @@
       <div class="govuk-grid-column-full">
         {% if migrationBannerEnabled %}
           {{migrationBanner()}}
+        {% endif %}
+
+        {% set hasMultipleSections = (details and details.length > 1 and details[0].items[0] | isArray) %}
+        {% if not hasMultipleSections %}
+        <span class="govuk-caption-l">{{ details[0].title }}</span>
         {% endif %}
         <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
         {% if callback and callback.message %}
@@ -35,8 +42,13 @@
           Check your uploaded file is visible. If not, upload it again.
         </div>
         {% endif %}
+
+        {% if isReadOnlySummary %}
+        <p class="govuk-body">You cannot change your answers.</p>
+        {% endif %}
+
         {% for detail in details %}
-          {{ summaryDetail(detail) }}
+          {{ summaryDetail(detail, isReadOnlySummary) }}
         {% endfor %}
 
         {% if fees and fees.details|length %}
@@ -49,7 +61,7 @@
           <p class="govuk-body">Total cost: £{{fees.total / 100 }}</p>
         {% endif %}
 
-        {% if not result.error  %}
+        {% if not result.error and not isReadOnlySummary %}
             <form method="post" enctype="multipart/form-data" autocomplete="off" novalidate>
               <input type="hidden" name="crumb" value="{{crumb}}"/>
 


### PR DESCRIPTION
# Description
This introduces a new flag `is_read_only_summary` that can be passed in the existing `metadata` payload when instantiating a new form. This instructs the summary page to not show "Change" links on the questions summary list and provides a direct back link.

The `is_read_only_summary` flag can be used along with `options.redirectPath` to direct the user to a read-only view of data they've previously provided.

Currently this fixes the back link and page title text for the summary page according to if the flag is set but it would be preferable for these values to be set using options bassed in my the service requesting a new form rather than fixed in the form logic -- if there are existing `options` payloads for customising this we should move to use those.

I'm applying the change to the existing custom form builder as well as the newer form builder adpater to not be blocked on deployments as the new patterns gains maturity and is released in different environments.

Note it doesn't look like individual flags like this are curretly covered by tests even though they can change the behaviour of the server, I'll look to do this in lining up with the methodology used by the newer form builder adapter.

Please delete options that are not relevant.

- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- ~[ ] This change requires a documentation update~

Read only summary page without change links

![image](https://github.com/user-attachments/assets/9525847c-ce8f-4ee8-8ffd-bf5c94e36bbb)

